### PR TITLE
fix(config)!: enforce path-safe plugin tags

### DIFF
--- a/.github/workflows/webui-ci.yml
+++ b/.github/workflows/webui-ci.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   webui:
-    name: Typecheck and Build
+    name: Lint, Test, Typecheck and Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -46,6 +46,14 @@ jobs:
       - name: Typecheck WebUI
         working-directory: webui
         run: pnpm typecheck
+
+      - name: Lint WebUI
+        working-directory: webui
+        run: pnpm lint
+
+      - name: Test WebUI
+        working-directory: webui
+        run: pnpm test
 
       - name: Build WebUI
         working-directory: webui

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,7 +1874,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "oxidns"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "oxidns"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 authors = ["Sven Shi <isvenshi@gmail.com>"]
 description = "A Rust-powered DNS engine inspired by MosDNS, designed for performance and complete configurability."

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -66,6 +66,19 @@ Debian 默认布局中，配置文件放在 `/etc/oxidns/config.yaml`，运行�
 
 尚未确定插件组合方式时，建议先阅读《[常见策略场景](scenarios.md)》，再回到本页查询字段含义。
 
+## 插件 tag 规则
+
+`plugins[].tag` 是插件实例的全局唯一机器标识，同时直接用于管理 API 路径：`/api/plugins/{tag}/...`。因此 tag 必须满足以下规则：
+
+- 长度为 1 到 64 个 ASCII 字符；
+- 仅可使用英文字母、数字、`_`、`-` 和 `.`；
+- `.` 只能分隔非空名称段，且每一段必须以字母或数字开头和结尾；
+- `qs.exec.`、`qs.match.`、`qs.cron.` 为 Quick Setup 保留前缀，不能在用户配置中使用。
+
+例如 `cache_main`、`cache.cn`、`prod.cache-01` 合法；`.`、`..`、`cache..cn`、`_cache`、`cache-`、`国内缓存` 和 `cache/main` 不合法。
+
+从旧版本升级时，请先使用新二进制执行 `oxidns check -c config.yaml`。如需修改历史 tag，必须同步更新所有 `$tag`、`jump/goto`、插件依赖和其他对该 tag 的引用；OxiDNS 不会自动重命名，以免静默改变请求处理逻辑。
+
 ## 环境变量替换
 
 OxiDNS 在启动、`oxidns check`、管理 API 配置校验和保存前校验时，先把 YAML **解析成数据结构**，再在字符串标量内部展开 `${VAR}` 占位符。`config.yaml` 文件本身不会被改写；WebUI 读取和保存配置时看到的仍然是原始占位符。

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -10,7 +10,25 @@ import ReleaseCard from '@site/src/components/ReleaseCard';
 ## 2026-06
 
 <div className="release-stack">
-   <ReleaseCard version="v1.4.0" badge="Minor Release" date="2026-06-24" defaultOpen>
+   <ReleaseCard version="v1.5.0" badge="Minor Release" date="2026-07-10" defaultOpen>
+       **版本定位**
+
+       - Minor Release。插件 `tag` 正式收敛为管理 API 路径中的安全、可读机器标识，避免浏览器、反向代理和 HTTP 实现在处理特殊路径字符时产生歧义。
+
+       **主要变更**
+
+       - `fix(config)` / `fix(api)`：`plugins[].tag` 统一限制为 1 到 64 个 ASCII 字符；支持字母、数字、`_`、`-` 和点分段，拒绝空段、`.`、`..`、首尾连接符及路径特殊字符。API 仍保持 `/api/plugins/{tag}/...`。
+       - `fix(webui)`：创建、重命名和 YAML 编辑器会显示具体 tag 错误并定位到对应值；WebUI 增加 tag 规则测试。
+       - `test(ci)`：新增 Rust/API/WebUI tag 边界覆盖，WebUI CI 执行 lint、test、typecheck 和 build。
+
+       **配置与升级说明**
+
+       - 这是破坏性配置变更。升级前请使用新二进制运行 `oxidns check -c config.yaml`。
+       - 历史 tag 若包含空格、中文、斜杠、百分号、前后点、连续点或以 `_` / `-` 开头或结尾，必须重命名；同时更新 `$tag`、`jump/goto` 和所有插件引用。
+       - `qs.exec.`、`qs.match.`、`qs.cron.` 为 Quick Setup 保留前缀，用户配置不得使用。
+   </ReleaseCard>
+
+   <ReleaseCard version="v1.4.0" badge="Minor Release" date="2026-06-24">
        **版本定位**
 
        - Minor Release。v1.4.0 的核心是补齐复杂网络环境下的“出口控制、上游诊断和并发裁决”能力：新增 `network.outbound` 统一出口层，新增 `oxidns probe upstream` 上游诊断命令，增强 `forward` 多上游并发结果选择，并优化缓存、DoH 入站、WebUI 升级体验和查询记录读取性能。

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
@@ -66,6 +66,19 @@ In the Debian default layout, the config file lives at `/etc/oxidns/config.yaml`
 
 When the plugin composition is still undecided, start from [Common Scenarios](scenarios.md), then return to this page for field details.
 
+## Plugin tag rules
+
+`plugins[].tag` is the globally unique machine identifier for a plugin instance and is used directly in management API paths: `/api/plugins/{tag}/...`. A tag must meet all of these rules:
+
+- It is 1 to 64 ASCII characters long.
+- It uses only ASCII letters, digits, `_`, `-`, and `.`.
+- A `.` may only separate non-empty name segments; every segment starts and ends with a letter or digit.
+- `qs.exec.`, `qs.match.`, and `qs.cron.` are reserved Quick Setup prefixes and cannot be used in user configuration.
+
+For example, `cache_main`, `cache.cn`, and `prod.cache-01` are valid. `.`, `..`, `cache..cn`, `_cache`, `cache-`, `国内缓存`, and `cache/main` are invalid.
+
+Before upgrading from an older version, run `oxidns check -c config.yaml` with the new binary. When renaming a historical tag, update every `$tag`, `jump/goto`, plugin dependency, and other reference to it. OxiDNS does not rename tags automatically because that could silently change request-processing behavior.
+
 ## Environment Variable Substitution
 
 During startup, `oxidns check`, management API validation, and validation before saving a config, OxiDNS first **parses the YAML into a data structure** and then expands `${VAR}` placeholders inside string scalars. The `config.yaml` file itself is not rewritten, so the WebUI still reads and saves the original placeholders.

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/releases.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/releases.md
@@ -10,7 +10,25 @@ import ReleaseCard from '@site/src/components/ReleaseCard';
 ## 2026-06
 
 <div className="release-stack">
-   <ReleaseCard version="v1.4.0" badge="Minor Release" date="2026-06-24" defaultOpen>
+   <ReleaseCard version="v1.5.0" badge="Minor Release" date="2026-07-10" defaultOpen>
+       **Release Scope**
+
+       - Minor Release. Plugin `tag` is now a safe, readable machine identifier in management API paths, removing ambiguity caused by special path characters across browsers, reverse proxies, and HTTP implementations.
+
+       **Changes**
+
+       - `fix(config)` / `fix(api)`: constrain `plugins[].tag` to 1 through 64 ASCII characters; allow letters, digits, `_`, `-`, and dot-separated segments; reject empty segments, `.`, `..`, boundary separators, and path-special characters. The API remains `/api/plugins/{tag}/...`.
+       - `fix(webui)`: plugin creation, rename, and the YAML editor report precise tag errors and locate the affected value; the WebUI gains tag-rule tests.
+       - `test(ci)`: add Rust/API/WebUI boundary coverage and run WebUI lint, test, typecheck, and build in CI.
+
+       **Compatibility and Upgrade Notes**
+
+       - This is a breaking configuration change. Before upgrading, run `oxidns check -c config.yaml` with the new binary.
+       - Historical tags containing whitespace, non-ASCII text, slashes, percent signs, leading/trailing dots, consecutive dots, or leading/trailing `_` / `-` must be renamed. Update every `$tag`, `jump/goto`, and plugin reference at the same time.
+       - `qs.exec.`, `qs.match.`, and `qs.cron.` are reserved Quick Setup prefixes and cannot be used in user configuration.
+   </ReleaseCard>
+
+   <ReleaseCard version="v1.4.0" badge="Minor Release" date="2026-06-24">
        **Release Scope**
 
        - Minor Release. v1.4.0 focuses on egress control, upstream diagnostics, and concurrent upstream decision making for complex network environments. It introduces `network.outbound` as a unified egress layer, adds the `oxidns probe upstream` diagnostics command, extends `forward` with configurable concurrent response selection, and improves cache behavior, DoH serving, WebUI upgrade flow, and query recorder read performance.

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -826,6 +826,42 @@ plugins:
     }
 
     #[tokio::test]
+    async fn config_validate_reports_invalid_plugin_tag_at_its_value() {
+        let validate = ConfigValidateHandler;
+        let response = validate
+            .handle(test_request(
+                Method::POST,
+                "/config/validate",
+                Bytes::from_static(
+                    b"
+plugins:
+  - tag: cache..cn
+    type: cache
+",
+                ),
+            ))
+            .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body should collect")
+            .to_bytes();
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("body should be json");
+        assert!(
+            value["diagnostic_details"][0]["message"]
+                .as_str()
+                .expect("diagnostic message")
+                .contains("Invalid plugin tag 'cache..cn'")
+        );
+        assert_eq!(value["diagnostic_details"][0]["line"], 3);
+        assert_eq!(value["diagnostic_details"][0]["column"], 10);
+        assert_eq!(value["diagnostic_details"][0]["end_column"], 19);
+    }
+
+    #[tokio::test]
     async fn config_get_and_save_handlers_round_trip_file_content() {
         AppClock::start();
         let temp = NamedTempFile::new().expect("temp file");

--- a/src/api/hub.rs
+++ b/src/api/hub.rs
@@ -16,7 +16,7 @@ use crate::api::route::{PrefixRoute, RouteKey, build_plugin_route_path, normaliz
 use crate::api::server::{ApiServerContext, build_tls_acceptor, run_api_server};
 #[cfg(feature = "webui")]
 use crate::api::static_files::StaticFileServer;
-use crate::config::types::{ApiConfig, ResolvedApiHttpConfig, is_valid_plugin_tag};
+use crate::config::types::{ApiConfig, ResolvedApiHttpConfig, validate_plugin_tag};
 use crate::infra::error::{DnsError, Result};
 use crate::infra::network::listen::parse_listen_addr;
 
@@ -475,11 +475,10 @@ impl ApiHub {
 }
 
 fn normalize_plugin_tag(plugin_tag: &str) -> Result<String> {
-    let plugin_tag = plugin_tag.trim();
-    if !is_valid_plugin_tag(plugin_tag) {
+    if let Err(reason) = validate_plugin_tag(plugin_tag) {
         return Err(DnsError::plugin(format!(
-            "api route plugin tag '{}' is invalid; only ASCII letters, digits, '_', '-', and '.' are allowed",
-            plugin_tag
+            "api route plugin tag '{}' is invalid: {}",
+            plugin_tag, reason
         )));
     }
     Ok(plugin_tag.to_string())

--- a/src/api/hub.rs
+++ b/src/api/hub.rs
@@ -16,7 +16,7 @@ use crate::api::route::{PrefixRoute, RouteKey, build_plugin_route_path, normaliz
 use crate::api::server::{ApiServerContext, build_tls_acceptor, run_api_server};
 #[cfg(feature = "webui")]
 use crate::api::static_files::StaticFileServer;
-use crate::config::types::{ApiConfig, ResolvedApiHttpConfig, validate_plugin_tag};
+use crate::config::types::{ApiConfig, ResolvedApiHttpConfig, validate_plugin_tag_path_segment};
 use crate::infra::error::{DnsError, Result};
 use crate::infra::network::listen::parse_listen_addr;
 
@@ -475,7 +475,7 @@ impl ApiHub {
 }
 
 fn normalize_plugin_tag(plugin_tag: &str) -> Result<String> {
-    if let Err(reason) = validate_plugin_tag(plugin_tag) {
+    if let Err(reason) = validate_plugin_tag_path_segment(plugin_tag) {
         return Err(DnsError::plugin(format!(
             "api route plugin tag '{}' is invalid: {}",
             plugin_tag, reason

--- a/src/api/route.rs
+++ b/src/api/route.rs
@@ -9,7 +9,7 @@ use ahash::AHashMap;
 use http::Method;
 
 use crate::api::ApiHandler;
-use crate::config::types::validate_plugin_tag;
+use crate::config::types::validate_plugin_tag_path_segment;
 use crate::infra::error::{DnsError, Result};
 
 #[derive(Clone, Debug)]
@@ -57,7 +57,7 @@ impl PrefixRoute {
 }
 
 pub(crate) fn build_plugin_route_path(plugin_tag: &str, subpath: &str) -> Result<String> {
-    if let Err(reason) = validate_plugin_tag(plugin_tag) {
+    if let Err(reason) = validate_plugin_tag_path_segment(plugin_tag) {
         return Err(DnsError::plugin(format!(
             "plugin tag '{}' is not valid for API route paths: {}",
             plugin_tag, reason

--- a/src/api/route.rs
+++ b/src/api/route.rs
@@ -9,7 +9,7 @@ use ahash::AHashMap;
 use http::Method;
 
 use crate::api::ApiHandler;
-use crate::config::types::is_valid_plugin_tag;
+use crate::config::types::validate_plugin_tag;
 use crate::infra::error::{DnsError, Result};
 
 #[derive(Clone, Debug)]
@@ -57,10 +57,10 @@ impl PrefixRoute {
 }
 
 pub(crate) fn build_plugin_route_path(plugin_tag: &str, subpath: &str) -> Result<String> {
-    if !is_valid_plugin_tag(plugin_tag) {
+    if let Err(reason) = validate_plugin_tag(plugin_tag) {
         return Err(DnsError::plugin(format!(
-            "plugin tag '{}' is not valid for API route paths; only ASCII letters, digits, '_', '-', and '.' are allowed",
-            plugin_tag
+            "plugin tag '{}' is not valid for API route paths: {}",
+            plugin_tag, reason
         )));
     }
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -116,6 +116,10 @@ fn http2_client() -> Client<HttpConnector, Empty<Bytes>> {
 fn test_build_plugin_route_path() {
     let route = build_plugin_route_path("cache_main", "/flush").expect("route should be built");
     assert_eq!(route, "/plugins/cache_main/flush");
+
+    let quick_setup_route =
+        build_plugin_route_path("qs.exec.seq.0.cache", "/flush").expect("system tag route");
+    assert_eq!(quick_setup_route, "/plugins/qs.exec.seq.0.cache/flush");
 }
 
 #[test]
@@ -126,12 +130,32 @@ fn test_build_plugin_route_path_without_subpath() {
 
 #[test]
 fn test_build_plugin_route_path_rejects_invalid_tag_segment() {
-    let err = build_plugin_route_path("Query Recorder 记录!*'()", "/records")
+    let err = build_plugin_route_path("cache..cn", "/records")
         .expect_err("invalid tag should be rejected");
     assert_eq!(
         err.to_string(),
-        "Plugin error: plugin tag 'Query Recorder 记录!*'()' is not valid for API route paths; only ASCII letters, digits, '_', '-', and '.' are allowed"
+        "Plugin error: plugin tag 'cache..cn' is not valid for API route paths: contains an empty dot-separated segment"
     );
+}
+
+#[test]
+fn test_build_plugin_route_path_rejects_dot_segments() {
+    for tag in [".", "..", ".cache", "cache."] {
+        assert!(
+            build_plugin_route_path(tag, "/records").is_err(),
+            "{tag} should be rejected before route registration"
+        );
+    }
+}
+
+#[test]
+fn test_plugin_registrar_does_not_trim_tag_before_validation() {
+    let addr = reserve_local_addr();
+    let hub = test_api_hub(addr, None);
+    let register = ApiRegister::new(hub);
+
+    assert!(register.plugin(" cache_main").is_err());
+    assert!(register.plugin("cache_main ").is_err());
 }
 
 #[test]

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -117,9 +117,15 @@ fn test_build_plugin_route_path() {
     let route = build_plugin_route_path("cache_main", "/flush").expect("route should be built");
     assert_eq!(route, "/plugins/cache_main/flush");
 
+    let sequence_tag = "a".repeat(crate::config::types::MAX_PLUGIN_TAG_LENGTH);
+    let quick_setup_tag = format!("qs.exec.{sequence_tag}.0.cache");
+    assert!(quick_setup_tag.len() > crate::config::types::MAX_PLUGIN_TAG_LENGTH);
     let quick_setup_route =
-        build_plugin_route_path("qs.exec.seq.0.cache", "/flush").expect("system tag route");
-    assert_eq!(quick_setup_route, "/plugins/qs.exec.seq.0.cache/flush");
+        build_plugin_route_path(&quick_setup_tag, "/flush").expect("synthetic system tag route");
+    assert_eq!(
+        quick_setup_route,
+        format!("/plugins/{quick_setup_tag}/flush")
+    );
 }
 
 #[test]
@@ -156,6 +162,10 @@ fn test_plugin_registrar_does_not_trim_tag_before_validation() {
 
     assert!(register.plugin(" cache_main").is_err());
     assert!(register.plugin("cache_main ").is_err());
+
+    let sequence_tag = "a".repeat(crate::config::types::MAX_PLUGIN_TAG_LENGTH);
+    let quick_setup_tag = format!("qs.exec.{sequence_tag}.0.cache");
+    assert!(register.plugin(&quick_setup_tag).is_ok());
 }
 
 #[test]

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -111,6 +111,29 @@ plugins:
     }
 
     #[test]
+    fn run_check_rejects_unsafe_plugin_tag() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_path = write_config(
+            temp.path(),
+            "config.yaml",
+            r#"
+plugins:
+  - tag: cache..cn
+    type: debug_print
+"#,
+        );
+
+        let err = run_check(&CheckOptions {
+            config: config_path,
+            working_dir: None,
+            graph: false,
+        })
+        .expect_err("unsafe plugin tag should fail config check");
+
+        assert!(err.to_string().contains("Invalid plugin tag 'cache..cn'"));
+    }
+
+    #[test]
     fn print_dependency_graph_renders_tree_from_top_level_plugins() {
         let summary = config::validate_text(
             r#"

--- a/src/config/diagnostic.rs
+++ b/src/config/diagnostic.rs
@@ -24,6 +24,8 @@ pub struct ConfigLocation {
 pub fn locate_in_config(config_text: &str, message: &str) -> Option<ConfigLocation> {
     let token = token_after(message, "Unknown plugin type: ")
         .or_else(|| quoted_after(message, "Unknown plugin type '"))
+        .or_else(|| quoted_after(message, "Invalid plugin tag '"))
+        .or_else(|| quoted_after(message, "Plugin tag '"))
         .or_else(|| quoted_after(message, "Duplicate plugin tag '"))
         .or_else(|| quoted_after(message, "references missing plugin '"))
         .or_else(|| quoted_after(message, "but '"))
@@ -64,4 +66,36 @@ fn locate_token(config_text: &str, token: &str) -> Option<(usize, usize, usize)>
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locates_invalid_plugin_tag() {
+        let config = "plugins:\n  - tag: cache..cn\n    type: cache\n";
+        let location = locate_in_config(
+            config,
+            "Invalid plugin tag 'cache..cn': contains an empty dot-separated segment",
+        )
+        .expect("invalid tag should be located");
+
+        assert_eq!(location.line, 2);
+        assert_eq!(location.column, 10);
+        assert_eq!(location.end_column, 19);
+    }
+
+    #[test]
+    fn locates_reserved_plugin_tag() {
+        let config = "plugins:\n  - tag: qs.exec.seq.0.cache\n    type: cache\n";
+        let location = locate_in_config(
+            config,
+            "Plugin tag 'qs.exec.seq.0.cache' uses a reserved quick-setup prefix",
+        )
+        .expect("reserved tag should be located");
+
+        assert_eq!(location.line, 2);
+        assert_eq!(location.column, 10);
+    }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -222,14 +222,30 @@ pub enum PluginTagValidationError {
     InvalidSegmentBoundary(String),
 }
 
-/// Validate a plugin tag used as a configuration identifier and API path
-/// segment.
+/// Validate a user-configured plugin tag.
+///
+/// The length limit is a product-level constraint for stable configuration
+/// identifiers. Runtime-generated quick-setup tags may be longer and should
+/// use [`validate_plugin_tag_path_segment`] when registering API routes.
 pub fn validate_plugin_tag(tag: &str) -> Result<(), PluginTagValidationError> {
     if tag.is_empty() {
         return Err(PluginTagValidationError::Empty);
     }
     if tag.len() > MAX_PLUGIN_TAG_LENGTH {
         return Err(PluginTagValidationError::TooLong);
+    }
+
+    validate_plugin_tag_path_segment(tag)
+}
+
+/// Validate only the syntax required for a safe, readable API path segment.
+///
+/// This intentionally does not apply [`MAX_PLUGIN_TAG_LENGTH`], because
+/// deterministic `qs.*` runtime tags include their validated parent tag plus
+/// quick-setup metadata and can therefore exceed the user-configured limit.
+pub(crate) fn validate_plugin_tag_path_segment(tag: &str) -> Result<(), PluginTagValidationError> {
+    if tag.is_empty() {
+        return Err(PluginTagValidationError::Empty);
     }
     if !tag.is_ascii() {
         return Err(PluginTagValidationError::NonAscii);

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -21,8 +21,12 @@ pub enum ConfigError {
     #[error("Plugin tag cannot be empty")]
     EmptyPluginTag,
 
-    #[error("Invalid plugin tag '{0}': only ASCII letters, digits, '_', '-', and '.' are allowed")]
-    InvalidPluginTag(String),
+    #[error("Invalid plugin tag '{tag}': {reason}")]
+    InvalidPluginTag {
+        tag: String,
+        #[source]
+        reason: PluginTagValidationError,
+    },
 
     #[error("Plugin tag '{0}' uses a reserved quick-setup prefix")]
     ReservedPluginTagPrefix(String),
@@ -160,8 +164,11 @@ impl Config {
             if plugin.tag.is_empty() {
                 return Err(ConfigError::EmptyPluginTag);
             }
-            if !is_valid_plugin_tag(&plugin.tag) {
-                return Err(ConfigError::InvalidPluginTag(plugin.tag.clone()));
+            if let Err(reason) = validate_plugin_tag(&plugin.tag) {
+                return Err(ConfigError::InvalidPluginTag {
+                    tag: plugin.tag.clone(),
+                    reason,
+                });
             }
             if is_reserved_plugin_tag(&plugin.tag) {
                 return Err(ConfigError::ReservedPluginTagPrefix(plugin.tag.clone()));
@@ -184,11 +191,76 @@ impl Config {
     }
 }
 
+/// Maximum byte length for a plugin tag.
+pub const MAX_PLUGIN_TAG_LENGTH: usize = 64;
+
+/// Detailed plugin-tag validation error.
+///
+/// Plugin tags are used as a single path segment in management API routes, so
+/// they deliberately use a small, readable ASCII grammar instead of relying
+/// on URL escaping behavior across clients and reverse proxies.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum PluginTagValidationError {
+    #[error("cannot be empty")]
+    Empty,
+
+    #[error("must be at most {MAX_PLUGIN_TAG_LENGTH} ASCII characters")]
+    TooLong,
+
+    #[error("must contain ASCII characters only")]
+    NonAscii,
+
+    #[error(
+        "contains invalid character '{0}'; only ASCII letters, digits, '_', '-', and '.' are allowed"
+    )]
+    InvalidCharacter(char),
+
+    #[error("contains an empty dot-separated segment")]
+    EmptySegment,
+
+    #[error("segment '{0}' must start and end with an ASCII letter or digit")]
+    InvalidSegmentBoundary(String),
+}
+
+/// Validate a plugin tag used as a configuration identifier and API path
+/// segment.
+pub fn validate_plugin_tag(tag: &str) -> Result<(), PluginTagValidationError> {
+    if tag.is_empty() {
+        return Err(PluginTagValidationError::Empty);
+    }
+    if tag.len() > MAX_PLUGIN_TAG_LENGTH {
+        return Err(PluginTagValidationError::TooLong);
+    }
+    if !tag.is_ascii() {
+        return Err(PluginTagValidationError::NonAscii);
+    }
+
+    if let Some(byte) = tag
+        .bytes()
+        .find(|byte| !byte.is_ascii_alphanumeric() && !matches!(byte, b'_' | b'-' | b'.'))
+    {
+        return Err(PluginTagValidationError::InvalidCharacter(char::from(byte)));
+    }
+
+    for segment in tag.split('.') {
+        if segment.is_empty() {
+            return Err(PluginTagValidationError::EmptySegment);
+        }
+
+        let bytes = segment.as_bytes();
+        if !bytes[0].is_ascii_alphanumeric() || !bytes[bytes.len() - 1].is_ascii_alphanumeric() {
+            return Err(PluginTagValidationError::InvalidSegmentBoundary(
+                segment.to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Return whether `tag` satisfies the plugin-tag grammar.
 pub fn is_valid_plugin_tag(tag: &str) -> bool {
-    !tag.is_empty()
-        && tag
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+    validate_plugin_tag(tag).is_ok()
 }
 
 pub fn is_reserved_plugin_tag(tag: &str) -> bool {
@@ -762,7 +834,15 @@ pub struct PluginConfig {
 
 #[cfg(test)]
 mod tests {
+    use serde::Deserialize;
+
     use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct PluginTagCase {
+        tag: String,
+        error: Option<String>,
+    }
 
     fn plugin(tag: &str, plugin_type: &str) -> PluginConfig {
         PluginConfig {
@@ -807,8 +887,44 @@ mod tests {
     }
 
     #[test]
+    fn test_plugin_tag_validation_matches_shared_cases() {
+        let cases: Vec<PluginTagCase> =
+            serde_json::from_str(include_str!("../../tests/fixtures/plugin_tag_cases.json"))
+                .expect("shared plugin tag cases should parse");
+
+        for case in cases {
+            let actual = validate_plugin_tag(&case.tag)
+                .err()
+                .map(plugin_tag_error_code);
+            assert_eq!(actual, case.error.as_deref(), "{:?}", case.tag);
+            assert_eq!(is_valid_plugin_tag(&case.tag), case.error.is_none());
+        }
+    }
+
+    fn plugin_tag_error_code(error: PluginTagValidationError) -> &'static str {
+        match error {
+            PluginTagValidationError::Empty => "empty",
+            PluginTagValidationError::TooLong => "too_long",
+            PluginTagValidationError::NonAscii => "non_ascii",
+            PluginTagValidationError::InvalidCharacter(_) => "invalid_character",
+            PluginTagValidationError::EmptySegment => "empty_segment",
+            PluginTagValidationError::InvalidSegmentBoundary(_) => "invalid_segment_boundary",
+        }
+    }
+
+    #[test]
     fn test_validate_rejects_invalid_plugin_tags() {
-        for tag in ["has space", "中文", "tag/slash", "tag:colon", "tag%20"] {
+        for tag in [
+            "has space",
+            "中文",
+            "tag/slash",
+            "tag:colon",
+            "tag%20",
+            ".",
+            "..",
+            "cache..cn",
+            "_cache",
+        ] {
             let config = Config {
                 include: Vec::new(),
                 runtime: RuntimeConfig::default(),
@@ -821,7 +937,7 @@ mod tests {
             let err = config
                 .validate()
                 .expect_err("should reject invalid plugin tag");
-            assert!(matches!(err, ConfigError::InvalidPluginTag(_)));
+            assert!(matches!(err, ConfigError::InvalidPluginTag { .. }));
         }
     }
 

--- a/tests/fixtures/plugin_tag_cases.json
+++ b/tests/fixtures/plugin_tag_cases.json
@@ -1,0 +1,23 @@
+[
+  { "tag": "cache", "error": null },
+  { "tag": "cache_main", "error": null },
+  { "tag": "cache-main", "error": null },
+  { "tag": "cache.cn", "error": null },
+  { "tag": "prod.cache-01", "error": null },
+  { "tag": "A1", "error": null },
+  { "tag": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "error": null },
+  { "tag": "", "error": "empty" },
+  { "tag": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "error": "too_long" },
+  { "tag": "中文", "error": "non_ascii" },
+  { "tag": "has space", "error": "invalid_character" },
+  { "tag": "tag/slash", "error": "invalid_character" },
+  { "tag": "tag\\backslash", "error": "invalid_character" },
+  { "tag": "tag%20", "error": "invalid_character" },
+  { "tag": ".cache", "error": "empty_segment" },
+  { "tag": "cache.", "error": "empty_segment" },
+  { "tag": "cache..cn", "error": "empty_segment" },
+  { "tag": ".", "error": "empty_segment" },
+  { "tag": "..", "error": "empty_segment" },
+  { "tag": "_cache", "error": "invalid_segment_boundary" },
+  { "tag": "cache-", "error": "invalid_segment_boundary" }
+]

--- a/webui/components/plugins/create-plugin-dialog.tsx
+++ b/webui/components/plugins/create-plugin-dialog.tsx
@@ -47,7 +47,11 @@ import {
 } from "@/components/plugins/plugin-config-fields-editor";
 import { PluginConfigModeEditor } from "@/components/plugins/plugin-config-mode-editor";
 import { isPluginKindSupported } from "@/lib/build-capabilities";
-import { isReservedPluginTag, isValidPluginTag } from "@/lib/plugin-tags";
+import {
+  isReservedPluginTag,
+  pluginTagValidationMessageKey,
+  validatePluginTag,
+} from "@/lib/plugin-tags";
 import { cn } from "@/lib/utils";
 
 const SequenceComposer = dynamic(
@@ -140,8 +144,9 @@ export function CreatePluginDialog({
   const normalizedInstanceName = instanceName.trim();
   const instanceNameError = useMemo(() => {
     if (!normalizedInstanceName) return null;
-    if (!isValidPluginTag(normalizedInstanceName)) {
-      return t(WEBUI.storeErrors.pluginNameInvalid);
+    const validationError = validatePluginTag(normalizedInstanceName);
+    if (validationError) {
+      return t(pluginTagValidationMessageKey(validationError));
     }
     if (isReservedPluginTag(normalizedInstanceName)) {
       return t(WEBUI.storeErrors.pluginNameReserved);

--- a/webui/components/plugins/plugin-detail-template.tsx
+++ b/webui/components/plugins/plugin-detail-template.tsx
@@ -29,7 +29,11 @@ import { usePluginAppliedStatus } from "@/hooks/use-plugin-applied";
 import { WEBUI } from "@/lib/i18n";
 import { pluginTypeLabel } from "@/lib/i18n/plugin-defined";
 import { useI18n } from "@/lib/i18n/provider";
-import { isReservedPluginTag, isValidPluginTag } from "@/lib/plugin-tags";
+import {
+  isReservedPluginTag,
+  pluginTagValidationMessageKey,
+  validatePluginTag,
+} from "@/lib/plugin-tags";
 import type { PluginDetailTemplateProps, PluginSummaryItem } from "./types";
 import { pluginTypeColors, pluginTypeIcons } from "./display";
 import { getPluginCatalogItem, renderPluginKindIcon } from "./catalog";
@@ -100,11 +104,13 @@ export function PluginDetailTemplate({
 
   const configBusy = isConfigSaving || isApplying || isRestarting;
   const normalizedNewName = newName.trim();
-  const nameValidationError =
-    normalizedNewName && !isValidPluginTag(normalizedNewName)
-      ? t(WEBUI.storeErrors.pluginNameInvalid)
-      : normalizedNewName && isReservedPluginTag(normalizedNewName)
-        ? t(WEBUI.storeErrors.pluginNameReserved)
+  const tagValidationError = normalizedNewName
+    ? validatePluginTag(normalizedNewName)
+    : null;
+  const nameValidationError = tagValidationError
+    ? t(pluginTagValidationMessageKey(tagValidationError))
+    : normalizedNewName && isReservedPluginTag(normalizedNewName)
+      ? t(WEBUI.storeErrors.pluginNameReserved)
       : null;
   const displayedNameError = nameError ?? nameValidationError;
   const nameSaveDisabled =

--- a/webui/lib/i18n/keys.ts
+++ b/webui/lib/i18n/keys.ts
@@ -715,6 +715,12 @@ export const WEBUI = {
     unsafeReferences: "webui.storeErrors.unsafeReferences",
     pluginNameRequired: "webui.storeErrors.pluginNameRequired",
     pluginNameInvalid: "webui.storeErrors.pluginNameInvalid",
+    pluginNameTooLong: "webui.storeErrors.pluginNameTooLong",
+    pluginNameNonAscii: "webui.storeErrors.pluginNameNonAscii",
+    pluginNameInvalidCharacter: "webui.storeErrors.pluginNameInvalidCharacter",
+    pluginNameEmptySegment: "webui.storeErrors.pluginNameEmptySegment",
+    pluginNameInvalidSegmentBoundary:
+      "webui.storeErrors.pluginNameInvalidSegmentBoundary",
     pluginNameReserved: "webui.storeErrors.pluginNameReserved",
     pluginNameUnchanged: "webui.storeErrors.pluginNameUnchanged",
     pluginNameExists: "webui.storeErrors.pluginNameExists",

--- a/webui/lib/i18n/locales/en-US/webui.ts
+++ b/webui/lib/i18n/locales/en-US/webui.ts
@@ -693,7 +693,15 @@ export const enUSWebui = {
       "Some references cannot be removed safely. Use replacement or fix them manually in the editor.",
     pluginNameRequired: "Plugin name is required",
     pluginNameInvalid:
+      "Plugin name must be a path-safe plugin tag",
+    pluginNameTooLong: "Plugin name must be at most 64 ASCII characters",
+    pluginNameNonAscii: "Plugin name must contain ASCII characters only",
+    pluginNameInvalidCharacter:
       "Plugin name can only contain ASCII letters, digits, underscores (_), hyphens (-), and dots (.)",
+    pluginNameEmptySegment:
+      "Plugin name cannot start or end with a dot, or contain consecutive dots",
+    pluginNameInvalidSegmentBoundary:
+      "Each dot-separated plugin name segment must start and end with a letter or digit",
     pluginNameReserved:
       "Plugin names cannot start with qs.exec., qs.match., or qs.cron.",
     pluginNameUnchanged: "Plugin name is unchanged",

--- a/webui/lib/i18n/locales/zh-CN/webui.ts
+++ b/webui/lib/i18n/locales/zh-CN/webui.ts
@@ -670,7 +670,14 @@ export const zhCNWebui = {
     unsafeReferences: "存在无法安全移除的引用，请改用替换或编辑器手动修复",
     pluginNameRequired: "插件名称不能为空",
     pluginNameInvalid:
+      "插件名称必须是可安全用于路径的插件标签",
+    pluginNameTooLong: "插件名称最多 64 个 ASCII 字符",
+    pluginNameNonAscii: "插件名称只能包含 ASCII 字符",
+    pluginNameInvalidCharacter:
       "插件名称只能包含英文字母、数字、下划线（_）、横线（-）和点（.）",
+    pluginNameEmptySegment: "插件名称不能以点开头或结尾，也不能包含连续的点",
+    pluginNameInvalidSegmentBoundary:
+      "每个点分插件名称段必须以字母或数字开头和结尾",
     pluginNameReserved:
       "插件名称不能以 qs.exec.、qs.match. 或 qs.cron. 开头",
     pluginNameUnchanged: "插件名称没有变化",

--- a/webui/lib/oxidns-yaml-codemirror.ts
+++ b/webui/lib/oxidns-yaml-codemirror.ts
@@ -44,6 +44,10 @@ import {
 import type { PluginInstance, PluginType } from "@/lib/types";
 import { DEFAULT_LOCALE, WEBUI, t as translate, type Locale } from "@/lib/i18n";
 import { pluginTypeLabel } from "@/lib/i18n/plugin-defined";
+import {
+  pluginTagValidationMessageKey,
+  validatePluginTag,
+} from "@/lib/plugin-tags";
 
 export type OxiDnsYamlEditorVariant =
   | "config"
@@ -728,6 +732,35 @@ function buildLocalDiagnostics(
       }
     }
 
+    if (context.variant === "config") {
+      const path = getYamlPath(state, lineNumber);
+      const tagMatch = checkText.match(
+        /^(\s*)(?:-\s*)?tag\s*:\s*(?:"([^"]*)"|'([^']*)'|([^\s#]+))/,
+      );
+      const tag = tagMatch?.[2] ?? tagMatch?.[3] ?? tagMatch?.[4];
+      if (
+        tag &&
+        path[0] === "plugins" &&
+        path[path.length - 1] === "tag" &&
+        !path.includes("args")
+      ) {
+        const validationError = validatePluginTag(tag);
+        if (validationError) {
+          const start = line.from + (tagMatch?.[0].lastIndexOf(tag) ?? 0);
+          diagnostics.push({
+            severity: "error",
+            message: translate(
+              locale,
+              pluginTagValidationMessageKey(validationError),
+            ),
+            from: start,
+            to: start + tag.length,
+            source: "OxiDNS",
+          });
+        }
+      }
+    }
+
     const jumpGotoMatch = checkText.match(/\b(jump|goto)\s+([A-Za-z0-9_.-]+)/);
     if (jumpGotoMatch) {
       const tag = jumpGotoMatch[2];
@@ -761,12 +794,20 @@ function diagnosticFromBackend(
       ? Math.min(diagnostic.line, state.doc.lines)
       : 1;
   const line = state.doc.line(lineNumber);
+  const from = Math.min(
+    line.to,
+    line.from + Math.max(0, (diagnostic.column ?? 1) - 1),
+  );
+  const to = Math.max(
+    Math.min(line.to, line.from + Math.max(0, (diagnostic.end_column ?? 2) - 1)),
+    Math.min(line.to, from + 1),
+  );
   return [
     {
       severity: diagnosticSeverity(diagnostic.severity),
       message,
-      from: line.from,
-      to: Math.max(line.from + 1, line.to),
+      from,
+      to,
       source: "OxiDNS",
     },
   ];

--- a/webui/lib/plugin-tags.test.ts
+++ b/webui/lib/plugin-tags.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import cases from "../../tests/fixtures/plugin_tag_cases.json";
+
+import {
+  isReservedPluginTag,
+  isValidPluginTag,
+  validatePluginTag,
+} from "./plugin-tags";
+
+type PluginTagCase = {
+  tag: string;
+  error: ReturnType<typeof validatePluginTag>;
+};
+
+describe("plugin tag validation", () => {
+  it.each(cases as PluginTagCase[])("matches the shared rule for $tag", (testCase) => {
+    expect(validatePluginTag(testCase.tag)).toBe(testCase.error);
+    expect(isValidPluginTag(testCase.tag)).toBe(testCase.error === null);
+  });
+
+  it("recognizes quick-setup reserved prefixes separately from syntax", () => {
+    expect(validatePluginTag("qs.exec.seq.0.cache")).toBeNull();
+    expect(isReservedPluginTag("qs.exec.seq.0.cache")).toBe(true);
+    expect(isReservedPluginTag("QS.exec.seq.0.cache")).toBe(false);
+  });
+});

--- a/webui/lib/plugin-tags.ts
+++ b/webui/lib/plugin-tags.ts
@@ -1,10 +1,63 @@
-const PLUGIN_TAG_PATTERN = /^[A-Za-z0-9_.-]+$/;
+import { WEBUI } from "./i18n";
+
+export const MAX_PLUGIN_TAG_LENGTH = 64;
+
 const RESERVED_PLUGIN_TAG_PREFIXES = ["qs.exec.", "qs.match.", "qs.cron."];
 
+export type PluginTagValidationError =
+  | "empty"
+  | "too_long"
+  | "non_ascii"
+  | "invalid_character"
+  | "empty_segment"
+  | "invalid_segment_boundary";
+
+/**
+ * Validate the readable, path-safe plugin tag grammar shared with the Rust
+ * configuration validator. Tags are a single API path segment, so dots are
+ * allowed only as separators between non-empty, alphanumeric-bounded parts.
+ */
+export function validatePluginTag(
+  tag: string,
+): PluginTagValidationError | null {
+  if (!tag) return "empty";
+  if (new TextEncoder().encode(tag).length > MAX_PLUGIN_TAG_LENGTH) {
+    return "too_long";
+  }
+  if (!/^[\x00-\x7F]+$/.test(tag)) return "non_ascii";
+  if (!/^[A-Za-z0-9_.-]+$/.test(tag)) return "invalid_character";
+
+  for (const segment of tag.split(".")) {
+    if (!segment) return "empty_segment";
+    if (!/^[A-Za-z0-9].*[A-Za-z0-9]$/.test(segment) && !/^[A-Za-z0-9]$/.test(segment)) {
+      return "invalid_segment_boundary";
+    }
+  }
+
+  return null;
+}
+
 export function isValidPluginTag(tag: string): boolean {
-  return PLUGIN_TAG_PATTERN.test(tag);
+  return validatePluginTag(tag) === null;
 }
 
 export function isReservedPluginTag(tag: string): boolean {
   return RESERVED_PLUGIN_TAG_PREFIXES.some((prefix) => tag.startsWith(prefix));
+}
+
+export function pluginTagValidationMessageKey(error: PluginTagValidationError) {
+  switch (error) {
+    case "empty":
+      return WEBUI.storeErrors.pluginNameRequired;
+    case "too_long":
+      return WEBUI.storeErrors.pluginNameTooLong;
+    case "non_ascii":
+      return WEBUI.storeErrors.pluginNameNonAscii;
+    case "invalid_character":
+      return WEBUI.storeErrors.pluginNameInvalidCharacter;
+    case "empty_segment":
+      return WEBUI.storeErrors.pluginNameEmptySegment;
+    case "invalid_segment_boundary":
+      return WEBUI.storeErrors.pluginNameInvalidSegmentBoundary;
+  }
 }

--- a/webui/lib/store.ts
+++ b/webui/lib/store.ts
@@ -56,7 +56,11 @@ import {
   type ConfigSnapshot,
 } from "./config-history";
 import { WEBUI, tClient } from "./i18n";
-import { isReservedPluginTag, isValidPluginTag } from "./plugin-tags";
+import {
+  isReservedPluginTag,
+  pluginTagValidationMessageKey,
+  validatePluginTag,
+} from "./plugin-tags";
 import {
   createProcessInstanceBaseline,
   hasProcessIdentityBaseline,
@@ -775,10 +779,11 @@ export const useAppStore = create<AppState>((set, get) => ({
         message: tClient(WEBUI.storeErrors.pluginNameRequired),
       };
     }
-    if (!isValidPluginTag(nextName)) {
+    const tagValidationError = validatePluginTag(nextName);
+    if (tagValidationError) {
       return {
         status: "invalid",
-        message: tClient(WEBUI.storeErrors.pluginNameInvalid),
+        message: tClient(pluginTagValidationMessageKey(tagValidationError)),
       };
     }
     if (isReservedPluginTag(nextName)) {

--- a/webui/package.json
+++ b/webui/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "lint": "eslint",
     "start": "next start",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",
@@ -52,6 +53,7 @@
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.7.4",
     "tailwindcss": "^4.2.4",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/webui/pnpm-lock.yaml
+++ b/webui/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.10(@types/node@25.6.0)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.1.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.4))
 
 packages:
 
@@ -325,11 +328,20 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -646,6 +658,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.4':
     resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
@@ -743,6 +761,9 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1434,6 +1455,104 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1443,6 +1562,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1545,6 +1667,12 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -1583,6 +1711,9 @@ packages:
 
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1775,6 +1906,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@xyflow/react@12.10.2':
     resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
     peerDependencies:
@@ -1871,6 +2031,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1952,6 +2116,10 @@ packages:
 
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2282,6 +2450,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2430,6 +2601,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2456,6 +2630,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.4.1:
     resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
@@ -2562,6 +2740,11 @@ packages:
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3181,6 +3364,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -3280,6 +3468,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3362,6 +3554,9 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3371,6 +3566,10 @@ packages:
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pkce-challenge@5.0.1:
@@ -3391,6 +3590,10 @@ packages:
 
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -3618,6 +3821,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -3714,6 +3922,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3735,9 +3946,15 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -3850,9 +4067,24 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.29:
     resolution: {integrity: sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==}
@@ -4008,6 +4240,90 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -4039,6 +4355,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4436,12 +4757,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4728,6 +5065,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@16.2.4': {}
 
   '@next/eslint-plugin-next@16.1.6':
@@ -4790,6 +5134,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@oxc-project/types@0.139.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5538,11 +5884,64 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -5628,6 +6027,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -5666,6 +6075,8 @@ snapshots:
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -5843,6 +6254,48 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.1.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.4))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.6(@types/node@25.6.0)(typescript@5.9.3)
+      vite: 8.1.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.4)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xyflow/react@12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@xyflow/system': 0.0.76
@@ -5980,6 +6433,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
@@ -6063,6 +6518,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001791: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -6405,6 +6862,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@2.3.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -6637,6 +7096,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -6675,6 +7138,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
@@ -6758,6 +7223,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -6815,6 +7284,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -7355,6 +7827,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.15: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -7460,6 +7934,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.3: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -7551,11 +8027,15 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  picomatch@4.0.5: {}
 
   pkce-challenge@5.0.1: {}
 
@@ -7575,6 +8055,12 @@ snapshots:
   postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7814,6 +8300,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -8017,6 +8524,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -8029,7 +8538,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -8149,10 +8662,21 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.29: {}
 
@@ -8349,6 +8873,46 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite@8.1.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.4):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      yaml: 2.8.4
+
+  vitest@4.1.10(@types/node@25.6.0)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.1.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.4)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.1.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.4))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
+
   w3c-keyname@2.2.8: {}
 
   web-streams-polyfill@3.3.3: {}
@@ -8401,6 +8965,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
- Restrict plugin tags to readable ASCII dot-separated path segments while keeping `/api/plugins/{tag}/...` routes unchanged.
- Add detailed validation diagnostics across config checks, API responses, WebUI forms, and the YAML editor, including Quick Setup namespace checks.
- Add shared Rust/WebUI boundary tests, CI coverage, migration docs, and bump release metadata to 1.5.0.

BREAKING CHANGE: Existing tags containing non-ASCII characters, whitespace, path separators, invalid dot segments, or boundary `_`/`-` characters must be renamed together with all dependent references.

Tests: just check; pnpm test; pnpm lint; pnpm typecheck; pnpm build; npm run build