### PR TITLE
fix(routeros): preserve longest leases during duplicate cleanup

### DIFF
--- a/src/plugin/executor/ros_address_list/api.rs
+++ b/src/plugin/executor/ros_address_list/api.rs
@@ -13,6 +13,7 @@ use mikrotik_rs::{Command, CommandBuilder};
 
 use super::manager::{
     AddressListFamily, AddressListKey, decode_owned_comment, parse_router_address,
+    parse_routeros_duration_secs,
 };
 use crate::infra::error::{DnsError, Result};
 use crate::infra::mikrotik::transport::{
@@ -59,7 +60,7 @@ pub(super) const DEFAULT_RECEIVE_TIMEOUT_SECS: u64 = 5;
 
 pub(super) type MikrotikApiTimeouts = RouterOsTimeouts;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub(super) struct RouterListEntry {
     /// RouterOS internal row id (for example `*123`).
     pub(super) id: String,
@@ -86,8 +87,6 @@ pub(super) trait MikrotikApi: Debug + Send + Sync {
         list4: Option<&str>,
         list6: Option<&str>,
     ) -> Result<Vec<RouterListEntry>>;
-    /// List entries matching one exact normalized key.
-    async fn list_entries_by_key(&self, key: &AddressListKey) -> Result<Vec<RouterListEntry>>;
     /// Upsert one plugin-owned address-list entry.
     ///
     /// Returning `Ok(None)` means a foreign entry already occupies the same
@@ -101,8 +100,9 @@ pub(super) trait MikrotikApi: Debug + Send + Sync {
         plugin_tag: &str,
         refresh_timeout: bool,
     ) -> Result<Option<()>>;
-    /// Delete one row by RouterOS internal id.
-    async fn delete_entry_by_id(&self, id: &str, family: AddressListFamily) -> Result<()>;
+    /// Re-read one row and delete it only while the ownership-relevant
+    /// snapshot still matches.
+    async fn delete_entry_if_matches(&self, expected: &RouterListEntry) -> Result<bool>;
 }
 
 #[derive(Debug, Clone)]
@@ -210,6 +210,21 @@ impl MikrotikRsClient {
             .await?;
         Ok(())
     }
+
+    async fn remove_entry_by_id(&self, id: &str, family: AddressListFamily) -> Result<()> {
+        let remove = CommandBuilder::new()
+            .command(address_list_command(family, ListOp::Remove))
+            .attribute(ADDRESS_ID_FIELD, Some(id))
+            .build();
+        match self
+            .send_rows_transport("remove address-list entry", remove)
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(error) if error.is_missing_item() => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -272,6 +287,32 @@ fn parse_router_list_entry(
         timeout,
         comment,
     }))
+}
+
+fn timeout_snapshot_matches(expected: Option<&str>, current: Option<&str>) -> bool {
+    match (expected, current) {
+        (None, None) => true,
+        (Some(expected), Some(current)) => {
+            match (
+                parse_routeros_duration_secs(expected),
+                parse_routeros_duration_secs(current),
+            ) {
+                // RouterOS counts timed entries down between the two reads.
+                // A larger current value means the row was refreshed after
+                // the snapshot and must not be removed by the older action.
+                (Some(expected), Some(current)) => current <= expected,
+                _ => current == expected,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn entry_matches_delete_snapshot(expected: &RouterListEntry, current: &RouterListEntry) -> bool {
+    current.id == expected.id
+        && current.key == expected.key
+        && current.comment == expected.comment
+        && timeout_snapshot_matches(expected.timeout.as_deref(), current.timeout.as_deref())
 }
 
 #[async_trait]
@@ -338,10 +379,6 @@ impl MikrotikApi for MikrotikRsClient {
         Ok(entries)
     }
 
-    async fn list_entries_by_key(&self, key: &AddressListKey) -> Result<Vec<RouterListEntry>> {
-        self.find_entries_by_key(key).await
-    }
-
     async fn upsert_owned_entry(
         &self,
         key: &AddressListKey,
@@ -373,10 +410,13 @@ impl MikrotikApi for MikrotikRsClient {
             return Ok(None);
         }
 
-        let mut iter = owned.into_iter();
-        let mut canonical = iter.next();
-        for extra in iter {
-            self.delete_entry_by_id(&extra.id, extra.key.family).await?;
+        let canonical = owned
+            .iter()
+            .position(|entry| entry.timeout.is_some() == timeout.is_some())
+            .unwrap_or_default();
+        let mut canonical = (!owned.is_empty()).then(|| owned.swap_remove(canonical));
+        for extra in owned {
+            self.delete_entry_if_matches(&extra).await?;
         }
 
         if let Some(existing) = canonical.take() {
@@ -384,8 +424,11 @@ impl MikrotikApi for MikrotikRsClient {
             // safest transition is delete-and-add when the timeout kind changes.
             let timeout_kind_changed = existing.timeout.is_some() != timeout.is_some();
             if timeout_kind_changed {
-                self.delete_entry_by_id(&existing.id, existing.key.family)
-                    .await?;
+                if !self.delete_entry_if_matches(&existing).await? {
+                    return Err(DnsError::plugin(
+                        "ros_address_list entry changed during timeout-kind transition",
+                    ));
+                }
                 self.add_entry(key, timeout, comment).await?;
                 return Ok(Some(()));
             }
@@ -413,19 +456,17 @@ impl MikrotikApi for MikrotikRsClient {
         Ok(Some(()))
     }
 
-    async fn delete_entry_by_id(&self, id: &str, family: AddressListFamily) -> Result<()> {
-        let remove = CommandBuilder::new()
-            .command(address_list_command(family, ListOp::Remove))
-            .attribute(ADDRESS_ID_FIELD, Some(id))
-            .build();
-        match self
-            .send_rows_transport("remove address-list entry", remove)
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(error) if error.is_missing_item() => Ok(()),
-            Err(error) => Err(error.into()),
-        }
+    async fn delete_entry_if_matches(&self, expected: &RouterListEntry) -> Result<bool> {
+        let current = self.find_entries_by_key(&expected.key).await?;
+        let Some(current) = current
+            .into_iter()
+            .find(|current| entry_matches_delete_snapshot(expected, current))
+        else {
+            return Ok(false);
+        };
+        self.remove_entry_by_id(&current.id, current.key.family)
+            .await?;
+        Ok(true)
     }
 }
 
@@ -471,5 +512,26 @@ mod tests {
         .expect_err("missing address field must remain an error");
 
         assert!(error.to_string().contains("missing 'address'"));
+    }
+
+    #[test]
+    fn delete_snapshot_allows_countdown_but_rejects_refresh_or_ownership_change() {
+        let key = AddressListKey::new("192.0.2.10".parse().expect("ip"), "policy".to_string());
+        let expected = RouterListEntry {
+            id: "*1".to_string(),
+            key,
+            timeout: Some("300s".to_string()),
+            comment: Some("oxi;pg=test;kind=D".to_string()),
+        };
+        let mut current = expected.clone();
+        current.timeout = Some("299s".to_string());
+        assert!(entry_matches_delete_snapshot(&expected, &current));
+
+        current.timeout = Some("301s".to_string());
+        assert!(!entry_matches_delete_snapshot(&expected, &current));
+
+        current.timeout = Some("299s".to_string());
+        current.comment = Some("operator-owned".to_string());
+        assert!(!entry_matches_delete_snapshot(&expected, &current));
     }
 }

--- a/src/plugin/executor/ros_address_list/manager.rs
+++ b/src/plugin/executor/ros_address_list/manager.rs
@@ -886,10 +886,24 @@ impl AddressListManager {
         // classifies the snapshot, mutates local state, and executes the
         // resulting precise persistent diff.
         let desired_comment = self.comment_for_persistent();
+        let mut owned_counts = AHashMap::<AddressListKey, usize>::new();
+        for entry in &existing {
+            if self.persistent_items.contains(&entry.key)
+                && decode_owned_comment(
+                    self.cfg.comment_prefix.as_str(),
+                    self.cfg.plugin_tag.as_str(),
+                    entry.comment.as_deref(),
+                )
+                .is_some()
+            {
+                *owned_counts.entry(entry.key.clone()).or_default() += 1;
+            }
+        }
         let correct_persistent = existing
             .iter()
             .filter(|entry| {
                 self.persistent_items.contains(&entry.key)
+                    && owned_counts.get(&entry.key) == Some(&1)
                     && entry.timeout.is_none()
                     && entry.comment.as_deref() == Some(desired_comment.as_str())
                     && decode_owned_comment(
@@ -951,51 +965,89 @@ impl AddressListManager {
             if self.persistent_items.contains(&entry.key) {
                 continue;
             }
-            match self.is_stale_persistent_entry_still_deletable(entry).await {
-                Ok(true) => {
-                    if let Err(error) = self
-                        .api
-                        .delete_entry_by_id(&entry.id, entry.key.family)
-                        .await
-                    {
-                        first_error.get_or_insert(error);
-                    }
+            if let Err(error) = self.api.delete_entry_if_matches(entry).await {
+                first_error.get_or_insert(error);
+            }
+        }
+
+        let now = captured_at_ms;
+        let policy = LeasePolicy::new(self.cfg.min_ttl, self.cfg.max_ttl, self.cfg.fixed_ttl);
+        let mut remote_dynamic =
+            AHashMap::<AddressListKey, (LeaseDeadline, LeaseDeadline, usize)>::new();
+        for entry in &existing {
+            if self.persistent_items.contains(&entry.key)
+                || !decode_owned_comment(
+                    self.cfg.comment_prefix.as_str(),
+                    self.cfg.plugin_tag.as_str(),
+                    entry.comment.as_deref(),
+                )
+                .is_some_and(|meta| meta.kind == OwnedCommentKind::Dynamic)
+            {
+                continue;
+            }
+            let remote = entry
+                .timeout
+                .as_deref()
+                .and_then(parse_routeros_duration_secs)
+                .filter(|seconds| *seconds > 0)
+                .map_or(LeaseDeadline::Timeless, |seconds| {
+                    LeaseDeadline::At(now.saturating_add(u64::from(seconds).saturating_mul(1_000)))
+                });
+            let desired = policy.cap_recovered(remote, now);
+            remote_dynamic
+                .entry(entry.key.clone())
+                .and_modify(|(current_desired, current_remote, count)| {
+                    *current_desired = current_desired.max(desired);
+                    *current_remote = current_remote.max(remote);
+                    *count = count.saturating_add(1);
+                })
+                .or_insert((desired, remote, 1));
+        }
+
+        let duplicate_dynamic = remote_dynamic
+            .iter()
+            .filter(|(key, (_, _, count))| {
+                *count > 1
+                    && !self
+                        .leases
+                        .get(*key)
+                        .is_some_and(|lease| lease.desired_revision() > scan_generation)
+            })
+            .map(|(key, (_, remote, _))| {
+                (
+                    key.clone(),
+                    remote
+                        .remaining_secs(now)
+                        .map(|seconds| format!("{seconds}s")),
+                )
+            })
+            .collect::<Vec<_>>();
+        let dynamic_comment = self.comment_for_dynamic();
+        let duplicate_results = join_all_bounded(
+            duplicate_dynamic.iter().map(|(key, timeout)| {
+                self.api.upsert_owned_entry(
+                    key,
+                    timeout.as_deref(),
+                    dynamic_comment.as_str(),
+                    self.cfg.comment_prefix.as_str(),
+                    self.cfg.plugin_tag.as_str(),
+                    false,
+                )
+            }),
+            UPSERT_PIPELINE_SIZE,
+        )
+        .await;
+        for ((key, _), result) in duplicate_dynamic.iter().zip(duplicate_results) {
+            match result {
+                Ok(Some(())) => {}
+                Ok(None) => {
+                    remote_dynamic.remove(key);
                 }
-                Ok(false) => {}
                 Err(error) => {
                     first_error.get_or_insert(error);
                 }
             }
         }
-
-        let now = captured_at_ms;
-        let remote_dynamic = existing
-            .iter()
-            .filter_map(|entry| {
-                decode_owned_comment(
-                    self.cfg.comment_prefix.as_str(),
-                    self.cfg.plugin_tag.as_str(),
-                    entry.comment.as_deref(),
-                )
-                .filter(|meta| meta.kind == OwnedCommentKind::Dynamic)
-                .map(|_| {
-                    let remote = entry
-                        .timeout
-                        .as_deref()
-                        .and_then(parse_routeros_duration_secs)
-                        .filter(|seconds| *seconds > 0)
-                        .map_or(LeaseDeadline::Timeless, |seconds| {
-                            LeaseDeadline::At(
-                                now.saturating_add(u64::from(seconds).saturating_mul(1_000)),
-                            )
-                        });
-                    let desired =
-                        LeasePolicy::new(self.cfg.min_ttl, self.cfg.max_ttl, self.cfg.fixed_ttl)
-                            .cap_recovered(remote, now);
-                    (entry.key.clone(), (desired, remote))
-                })
-            })
-            .collect::<AHashMap<_, _>>();
 
         // A snapshot may race successful writes. Newer generations win;
         // everything else follows actual RouterOS state, including timeless
@@ -1012,7 +1064,7 @@ impl AddressListManager {
         for key in missing_newer {
             self.leases.mark_unsynced(&key);
         }
-        for (key, (desired, remote)) in remote_dynamic {
+        for (key, (desired, remote, _)) in remote_dynamic {
             let keep_newer = self
                 .leases
                 .get(&key)
@@ -1031,23 +1083,6 @@ impl AddressListManager {
             self.empty_state_needs_reconcile = false;
         }
         Ok(())
-    }
-
-    async fn is_stale_persistent_entry_still_deletable(
-        &self,
-        entry: &RouterListEntry,
-    ) -> Result<bool> {
-        let current_entries = self.api.list_entries_by_key(&entry.key).await?;
-        Ok(current_entries.into_iter().any(|current| {
-            current.id == entry.id
-                && !self.persistent_items.contains(&current.key)
-                && decode_owned_comment(
-                    self.cfg.comment_prefix.as_str(),
-                    self.cfg.plugin_tag.as_str(),
-                    current.comment.as_deref(),
-                )
-                .is_some_and(|meta| meta.kind == OwnedCommentKind::Persistent)
-        }))
     }
 
     fn spawn_background_reconcile(&mut self, tag: String) {
@@ -1349,22 +1384,7 @@ impl AddressListManager {
     }
 
     async fn cleanup_entry_if_still_owned(&self, entry: &RouterListEntry) -> Result<()> {
-        let current = self.api.list_entries_by_key(&entry.key).await?;
-        let still_owned = current.iter().any(|candidate| {
-            candidate.id == entry.id
-                && candidate.key == entry.key
-                && decode_owned_comment(
-                    self.cfg.comment_prefix.as_str(),
-                    self.cfg.plugin_tag.as_str(),
-                    candidate.comment.as_deref(),
-                )
-                .is_some()
-        });
-        if still_owned {
-            self.api
-                .delete_entry_by_id(&entry.id, entry.key.family)
-                .await?;
-        }
+        self.api.delete_entry_if_matches(entry).await?;
         Ok(())
     }
 
@@ -1833,7 +1853,7 @@ fn defer_address_observation(
     }
 }
 
-fn parse_routeros_duration_secs(raw: &str) -> Option<u32> {
+pub(super) fn parse_routeros_duration_secs(raw: &str) -> Option<u32> {
     let raw = raw.trim();
     if raw.is_empty() {
         return None;
@@ -1896,8 +1916,104 @@ pub(super) fn parse_router_address(family: AddressListFamily, raw: &str) -> Opti
 #[cfg(test)]
 mod observation_tests {
     use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
 
     use super::*;
+
+    #[derive(Debug, Default)]
+    struct DuplicateApi {
+        entries: Mutex<Vec<RouterListEntry>>,
+    }
+
+    #[async_trait]
+    impl MikrotikApi for DuplicateApi {
+        async fn list_entries(
+            &self,
+            _list4: Option<&str>,
+            _list6: Option<&str>,
+        ) -> Result<Vec<RouterListEntry>> {
+            Ok(self.entries.lock().expect("entries").clone())
+        }
+
+        async fn upsert_owned_entry(
+            &self,
+            key: &AddressListKey,
+            timeout: Option<&str>,
+            comment: &str,
+            comment_prefix: &str,
+            plugin_tag: &str,
+            _refresh_timeout: bool,
+        ) -> Result<Option<()>> {
+            let mut entries = self.entries.lock().expect("entries");
+            let canonical = entries
+                .iter()
+                .find(|entry| {
+                    entry.key == *key
+                        && decode_owned_comment(
+                            comment_prefix,
+                            plugin_tag,
+                            entry.comment.as_deref(),
+                        )
+                        .is_some()
+                })
+                .map(|entry| entry.id.clone());
+            let Some(canonical) = canonical else {
+                return Ok(None);
+            };
+            entries.retain(|entry| {
+                entry.key != *key
+                    || entry.id == canonical
+                    || decode_owned_comment(comment_prefix, plugin_tag, entry.comment.as_deref())
+                        .is_none()
+            });
+            let entry = entries
+                .iter_mut()
+                .find(|entry| entry.id == canonical)
+                .expect("canonical entry");
+            entry.timeout = timeout.map(str::to_string);
+            entry.comment = Some(comment.to_string());
+            Ok(Some(()))
+        }
+
+        async fn delete_entry_if_matches(&self, expected: &RouterListEntry) -> Result<bool> {
+            let mut entries = self.entries.lock().expect("entries");
+            let Some(index) = entries.iter().position(|entry| entry == expected) else {
+                return Ok(false);
+            };
+            entries.remove(index);
+            Ok(true)
+        }
+    }
+
+    fn duplicate_config() -> AddressListManagerConfig {
+        AppClock::start();
+        AddressListManagerConfig {
+            plugin_tag: "duplicate-test".to_string(),
+            address_list4: Some("policy".to_string()),
+            address_list6: None,
+            persistent_items: AHashSet::new(),
+            comment_prefix: "oxi".to_string(),
+            min_ttl: 1,
+            max_ttl: 3_600,
+            fixed_ttl: None,
+        }
+    }
+
+    fn list_entry(
+        id: &str,
+        key: &AddressListKey,
+        timeout: Option<&str>,
+        kind: OwnedCommentKind,
+    ) -> RouterListEntry {
+        RouterListEntry {
+            id: id.to_string(),
+            key: key.clone(),
+            timeout: timeout.map(str::to_string),
+            comment: Some(encode_comment("oxi", "duplicate-test", kind)),
+        }
+    }
 
     #[test]
     fn routeros_duration_parser_accepts_composite_values() {
@@ -1905,6 +2021,61 @@ mod observation_tests {
         assert_eq!(parse_routeros_duration_secs("300s"), Some(300));
         assert_eq!(parse_routeros_duration_secs("none"), None);
         assert_eq!(parse_routeros_duration_secs("5m30"), None);
+    }
+
+    #[tokio::test]
+    async fn reconcile_keeps_longest_dynamic_timeout_and_removes_duplicates() {
+        let api = Arc::new(DuplicateApi::default());
+        let key = AddressListKey::new(
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 20)),
+            "policy".to_string(),
+        );
+        let short = list_entry("*short", &key, Some("30s"), OwnedCommentKind::Dynamic);
+        let long = list_entry("*long", &key, Some("300s"), OwnedCommentKind::Dynamic);
+        api.entries
+            .lock()
+            .expect("entries")
+            .extend([short.clone(), long.clone()]);
+        let mut manager = AddressListManager::new(api.clone(), duplicate_config());
+        let now = now_millis();
+
+        manager
+            .apply_reconcile_snapshot_at(vec![short, long], 0, now)
+            .await
+            .expect("reconcile");
+
+        let entries = api.entries.lock().expect("entries");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].timeout.as_deref(), Some("300s"));
+        assert_eq!(
+            manager.leases.get(&key).expect("lease").desired(),
+            LeaseDeadline::At(now + 300_000)
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_removes_duplicate_correct_persistent_entries() {
+        let api = Arc::new(DuplicateApi::default());
+        let key = AddressListKey::new(
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 21)),
+            "policy".to_string(),
+        );
+        let first = list_entry("*first", &key, None, OwnedCommentKind::Persistent);
+        let second = list_entry("*second", &key, None, OwnedCommentKind::Persistent);
+        api.entries
+            .lock()
+            .expect("entries")
+            .extend([first.clone(), second.clone()]);
+        let mut config = duplicate_config();
+        config.persistent_items.insert(key);
+        let mut manager = AddressListManager::new(api.clone(), config);
+
+        manager
+            .apply_reconcile_snapshot_at(vec![first, second], 0, now_millis())
+            .await
+            .expect("reconcile");
+
+        assert_eq!(api.entries.lock().expect("entries").len(), 1);
     }
 
     #[tokio::test]

--- a/src/plugin/executor/ros_address_list/mod.rs
+++ b/src/plugin/executor/ros_address_list/mod.rs
@@ -1273,10 +1273,6 @@ mod tests {
             Ok(Vec::new())
         }
 
-        async fn list_entries_by_key(&self, _key: &AddressListKey) -> Result<Vec<RouterListEntry>> {
-            Ok(Vec::new())
-        }
-
         async fn upsert_owned_entry(
             &self,
             _key: &AddressListKey,
@@ -1294,8 +1290,8 @@ mod tests {
             Ok(Some(()))
         }
 
-        async fn delete_entry_by_id(&self, _id: &str, _family: AddressListFamily) -> Result<()> {
-            Ok(())
+        async fn delete_entry_if_matches(&self, _expected: &RouterListEntry) -> Result<bool> {
+            Ok(false)
         }
     }
 
@@ -1357,19 +1353,6 @@ mod tests {
             }
 
             Ok(entries)
-        }
-
-        async fn list_entries_by_key(&self, key: &AddressListKey) -> Result<Vec<RouterListEntry>> {
-            let state = self
-                .state
-                .lock()
-                .map_err(|_| DnsError::plugin("mock api lock poisoned"))?;
-            Ok(state
-                .entries
-                .values()
-                .filter(|entry| entry.key == *key)
-                .cloned()
-                .collect())
         }
 
         async fn upsert_owned_entry(
@@ -1439,7 +1422,7 @@ mod tests {
             Ok(Some(()))
         }
 
-        async fn delete_entry_by_id(&self, id: &str, _family: AddressListFamily) -> Result<()> {
+        async fn delete_entry_if_matches(&self, expected: &RouterListEntry) -> Result<bool> {
             let mut state = self
                 .state
                 .lock()
@@ -1447,12 +1430,13 @@ mod tests {
             let key = state
                 .entries
                 .iter()
-                .find(|(_, entry)| entry.id == id)
+                .find(|(_, entry)| *entry == expected)
                 .map(|(key, _)| key.clone());
             if let Some(key) = key {
                 state.entries.remove(&key);
+                return Ok(true);
             }
-            Ok(())
+            Ok(false)
         }
     }
 

--- a/src/plugin/executor/ros_route/manager.rs
+++ b/src/plugin/executor/ros_route/manager.rs
@@ -238,6 +238,14 @@ fn is_validation_comment(prefix: &str, plugin_tag: &str, comment: &str) -> bool 
         ))
 }
 
+fn deadline_is_later(candidate: LeaseDeadline, current: LeaseDeadline) -> bool {
+    match (candidate, current) {
+        (LeaseDeadline::Timeless, LeaseDeadline::At(_)) => true,
+        (LeaseDeadline::At(candidate), LeaseDeadline::At(current)) => candidate > current,
+        _ => false,
+    }
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum SyncState {
     PendingCreate,
@@ -1228,12 +1236,6 @@ impl RouteManager {
 
         let mut seen = AHashSet::new();
         for (key, mut candidates) in owned {
-            let (route, meta) = candidates.remove(0);
-            for (duplicate, _) in candidates {
-                if let Err(error) = self.delete_route_if_still_owned(&duplicate).await {
-                    first_error.get_or_insert(error);
-                }
-            }
             seen.insert(key.clone());
             let Some(gateway) = self.gateway_for(key.family()).map(str::to_string) else {
                 continue;
@@ -1243,6 +1245,22 @@ impl RouteManager {
                     &self.cfg.comment_prefix,
                     &self.cfg.plugin_tag,
                 );
+                let canonical = candidates
+                    .iter()
+                    .position(|(route, meta)| {
+                        meta.kind == RouteCommentKind::Persistent
+                            && route.gateway.as_deref() == Some(gateway.as_str())
+                            && route.distance == Some(self.cfg.distance)
+                            && !route.disabled
+                            && route.comment.as_deref() == Some(expected.as_str())
+                    })
+                    .unwrap_or_default();
+                let (route, meta) = candidates.swap_remove(canonical);
+                for (duplicate, _) in candidates {
+                    if let Err(error) = self.delete_route_if_still_owned(&duplicate).await {
+                        first_error.get_or_insert(error);
+                    }
+                }
                 let dirty = meta.kind != RouteCommentKind::Persistent
                     || route.gateway.as_deref() != Some(gateway.as_str())
                     || route.distance != Some(self.cfg.distance)
@@ -1262,6 +1280,93 @@ impl RouteManager {
                     },
                 );
                 continue;
+            }
+
+            let newer = self
+                .leases
+                .get(&key)
+                .is_some_and(|lease| lease.desired_revision() > snapshot.generation);
+            let mut recovered_deadline = None;
+            let mut recovered_seen = 0;
+            let mut canonical_dynamic = None;
+            for (index, (_, meta)) in candidates.iter().enumerate() {
+                if meta.kind != RouteCommentKind::Dynamic {
+                    continue;
+                }
+                let deadline = self
+                    .policy()
+                    .cap_recovered(meta.expires_at_ms, meta.last_seen_ms);
+                if recovered_deadline.is_none_or(|current| deadline_is_later(deadline, current)) {
+                    recovered_deadline = Some(deadline);
+                    canonical_dynamic = Some(index);
+                }
+                recovered_seen = recovered_seen.max(meta.last_seen_ms);
+            }
+
+            if let Some(canonical) = canonical_dynamic {
+                let (route, _) = candidates.swap_remove(canonical);
+                for (duplicate, _) in candidates {
+                    if let Err(error) = self.delete_route_if_still_owned(&duplicate).await {
+                        first_error.get_or_insert(error);
+                    }
+                }
+                let deadline = recovered_deadline.expect("dynamic candidate has a deadline");
+                if deadline.is_expired(now) && !newer {
+                    self.routes.insert(
+                        key,
+                        RouteState {
+                            gateway,
+                            distance: self.cfg.distance,
+                            router_id: Some(route.id),
+                            sync_state: SyncState::PendingDynamicDelete,
+                        },
+                    );
+                    continue;
+                }
+                if !newer {
+                    self.leases.recover(
+                        key.clone(),
+                        deadline,
+                        recovered_seen,
+                        snapshot.generation,
+                        now,
+                    );
+                }
+                let lease = self.leases.get(&key).copied();
+                let expected = lease.map(|lease| {
+                    RouteCommentCodec::encode_dynamic(
+                        &self.cfg.comment_prefix,
+                        &self.cfg.plugin_tag,
+                        lease.desired(),
+                        lease.last_observed_ms(),
+                    )
+                });
+                let dirty = newer
+                    || route.gateway.as_deref() != Some(gateway.as_str())
+                    || route.distance != Some(self.cfg.distance)
+                    || route.disabled
+                    || expected.as_deref() != route.comment.as_deref();
+                self.routes.insert(
+                    key,
+                    RouteState {
+                        gateway,
+                        distance: self.cfg.distance,
+                        router_id: Some(route.id),
+                        sync_state: if dirty {
+                            SyncState::Dirty
+                        } else {
+                            SyncState::Synced
+                        },
+                    },
+                );
+                continue;
+            }
+
+            let (route, meta) = candidates.swap_remove(0);
+            for (duplicate, _) in candidates {
+                if let Err(error) = self.delete_route_if_still_owned(&duplicate).await {
+                    first_error.get_or_insert(error);
+                }
             }
             if meta.kind == RouteCommentKind::Persistent {
                 if self
@@ -1291,61 +1396,6 @@ impl RouteManager {
                 );
                 continue;
             }
-            let deadline = self
-                .policy()
-                .cap_recovered(meta.expires_at_ms, meta.last_seen_ms);
-            let newer = self
-                .leases
-                .get(&key)
-                .is_some_and(|lease| lease.desired_revision() > snapshot.generation);
-            if deadline.is_expired(now) && !newer {
-                self.routes.insert(
-                    key,
-                    RouteState {
-                        gateway,
-                        distance: self.cfg.distance,
-                        router_id: Some(route.id),
-                        sync_state: SyncState::PendingDynamicDelete,
-                    },
-                );
-                continue;
-            }
-            if !newer {
-                self.leases.recover(
-                    key.clone(),
-                    deadline,
-                    meta.last_seen_ms,
-                    snapshot.generation,
-                    now,
-                );
-            }
-            let lease = self.leases.get(&key).copied();
-            let expected = lease.map(|lease| {
-                RouteCommentCodec::encode_dynamic(
-                    &self.cfg.comment_prefix,
-                    &self.cfg.plugin_tag,
-                    lease.desired(),
-                    lease.last_observed_ms(),
-                )
-            });
-            let dirty = newer
-                || route.gateway.as_deref() != Some(gateway.as_str())
-                || route.distance != Some(self.cfg.distance)
-                || route.disabled
-                || expected.as_deref() != route.comment.as_deref();
-            self.routes.insert(
-                key,
-                RouteState {
-                    gateway,
-                    distance: self.cfg.distance,
-                    router_id: Some(route.id),
-                    sync_state: if dirty {
-                        SyncState::Dirty
-                    } else {
-                        SyncState::Synced
-                    },
-                },
-            );
         }
 
         let local_keys = self.routes.keys().cloned().collect::<Vec<_>>();
@@ -1377,7 +1427,11 @@ impl RouteManager {
         if let Err(error) = self.sync_keys(keys, now).await {
             first_error.get_or_insert(error);
         }
-        if self.persistent.is_empty() && self.leases.is_empty() {
+        if first_error.is_none()
+            && self.persistent.is_empty()
+            && self.leases.is_empty()
+            && self.routes.is_empty()
+        {
             self.empty_state_needs_reconcile = false;
         }
         first_error.map_or(Ok(()), Err)
@@ -1766,6 +1820,7 @@ mod tests {
         connections: Mutex<AHashSet<IpAddr>>,
         validation_attempts: AtomicUsize,
         validation_failures: AtomicUsize,
+        delete_failures: AtomicUsize,
     }
 
     impl MockApi {
@@ -1877,6 +1932,15 @@ mod tests {
         }
 
         async fn delete_route_if_matches(&self, expected: &RouterRoute) -> Result<bool> {
+            if self
+                .delete_failures
+                .try_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(DnsError::plugin("route delete unavailable"));
+            }
             let mut routes = self.routes.lock().expect("routes");
             let Some(index) = routes.iter().position(|route| route == expected) else {
                 return Ok(false);
@@ -2149,6 +2213,105 @@ mod tests {
 
         assert_eq!(api.routes().len(), 1);
         assert_eq!(api.routes()[0].comment.as_deref(), Some("operator-owned"));
+    }
+
+    #[tokio::test]
+    async fn reconcile_keeps_the_longest_dynamic_duplicate_lease() {
+        let api = Arc::new(MockApi::default());
+        let mut manager = RouteManager::new(api.clone(), config(None, false));
+        let key = RouteKey::new("203.0.113.94".parse().expect("ip"), "policy".to_string());
+        let now = now_millis();
+        let route = |id: &str, deadline, seen| RouterRoute {
+            id: id.to_string(),
+            family: RouteFamily::Ipv4,
+            dst_address: key.dst_address(),
+            routing_table: key.table.clone(),
+            gateway: Some("192.0.2.1".to_string()),
+            distance: Some(100),
+            comment: Some(RouteCommentCodec::encode_dynamic(
+                "fdns",
+                "route-test",
+                deadline,
+                seen,
+            )),
+            disabled: false,
+        };
+        let expired = route(
+            "*expired",
+            LeaseDeadline::At(now.saturating_sub(1_000)),
+            now.saturating_sub(60_000),
+        );
+        let valid = route(
+            "*valid",
+            LeaseDeadline::At(now.saturating_add(300_000)),
+            now,
+        );
+        api.routes
+            .lock()
+            .expect("routes")
+            .extend([expired.clone(), valid.clone()]);
+
+        manager
+            .apply_snapshot(VersionedSnapshot {
+                generation: 0,
+                value: vec![expired, valid],
+            })
+            .await
+            .expect("reconcile");
+
+        let routes = api.routes();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].id, "*valid");
+        assert!(
+            manager
+                .leases
+                .get(&key)
+                .is_some_and(|lease| !lease.desired().is_expired(now))
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_validation_cleanup_keeps_empty_reconcile_retry_enabled() {
+        let api = Arc::new(MockApi::default());
+        let mut manager = RouteManager::new(api.clone(), config(None, false));
+        let key = RouteKey::new("198.18.0.11".parse().expect("ip"), "policy".to_string());
+        let route = RouterRoute {
+            id: "*validation-retry".to_string(),
+            family: RouteFamily::Ipv4,
+            dst_address: key.dst_address(),
+            routing_table: key.table,
+            gateway: Some("192.0.2.1".to_string()),
+            distance: Some(100),
+            comment: Some(format!(
+                "{};nonce=2",
+                RouteCommentCodec::prefix("fdns", "route-test", COMMENT_KIND_GATEWAY_CHECK)
+            )),
+            disabled: true,
+        };
+        api.routes.lock().expect("routes").push(route.clone());
+        api.delete_failures.store(1, Ordering::Release);
+
+        assert!(
+            manager
+                .apply_snapshot(VersionedSnapshot {
+                    generation: 0,
+                    value: vec![route],
+                })
+                .await
+                .is_err()
+        );
+        assert!(manager.empty_state_needs_reconcile);
+        assert_eq!(api.routes().len(), 1);
+
+        manager
+            .apply_snapshot(VersionedSnapshot {
+                generation: 0,
+                value: api.routes(),
+            })
+            .await
+            .expect("retry cleanup");
+        assert!(api.routes().is_empty());
+        assert!(!manager.empty_state_needs_reconcile);
     }
 
     #[tokio::test]


### PR DESCRIPTION
- merge duplicate route and address-list state using the longest valid lease
- retry empty route reconciliation when validation or cleanup fails
- revalidate address-list ownership and timeout state before deletion
- converge duplicate persistent entries through safe canonical selection