### PR TITLE
Enhance query recorder with coordinated database access and space reclamation

### DIFF
--- a/docs/docs/plugin-reference/executor.mdx
+++ b/docs/docs/plugin-reference/executor.mdx
@@ -1788,7 +1788,7 @@ old-static.example.com static.example.net
 - tag: query_recorder_main
   type: query_recorder
   args:
-    # SQLite 文件路径；不同 recorder 应使用不同 path
+    # SQLite 文件路径；多个 recorder 可以共用同一文件
     path: "./data/query-recorder-main.sqlite"
     # 热路径入队缓冲大小
     queue_size: 8192
@@ -1865,7 +1865,10 @@ old-static.example.com static.example.net
   - `qr_<safe_tag>_<fnv64hex>_v1_meta`
 - `records` 主表只保存固定字段集合；`steps` 表保存 `sequence` 路径事件，用于执行路径分析和命中率统计；`questions` 表是从 `questions_json` 派生的索引表，用于加速 qname/qtype 查询；`meta` 表记录已完成的派生表迁移。
 - 每个 recorder 独占自己的有界队列、SQLite 连接、后台写线程、内存 tail 和 SSE 广播器。
-- 默认假定不同 recorder 使用不同 `path`；v1 不做跨 recorder 写线程复用或路径协调。
+- 共用同一 `path` 的 recorder 会按规范化文件路径协调 reader、writer 和维护操作；表和内存状态仍按 tag 隔离。
+- 定时保留期清理会删除过期记录、回收全部完整空闲页，并在最后截断 WAL。只有删除产生完整空闲页时，数据库文件才会实际变小；少量删除可能只释放页内空间供后续写入复用。
+- 旧数据库若仍是 `auto_vacuum=NONE`，第一次定时清理或手动清空会执行一次完整 `VACUUM`，迁移到 `INCREMENTAL` 模式。该过程可能短暂停止 recorder 的数据库读写，并需要额外临时磁盘空间，但不会阻塞 DNS 请求处理。
+- 维护失败不会终止后台 writer；定时任务会在后续周期重试，并通过结构化日志报告回收前后的页数、文件大小和失败阶段。
 
 ### 数据结构约定
 
@@ -1912,7 +1915,8 @@ old-static.example.com static.example.net
   - 返回单条完整记录，并附带 `steps`。
 - `DELETE /plugins/<tag>/records`
   - 清空当前 recorder 的所有历史记录和 `steps`，并清空内存 tail。
-  - 操作会先 flush 后台写入队列，返回 `cleared_records` 表示删除的主表记录数。
+  - 操作会先 flush 后台写入队列，再用小批次自动提交删除记录；每批删除和每批页面回收后都会截断 WAL，避免一个覆盖整次清空的大事务导致 WAL 持续增长。返回 `cleared_records` 表示删除的主表记录数。
+  - 若历史已删除但磁盘回收失败，接口返回 `query_recorder_clear_failed`，错误信息会明确说明历史已经清除；后续维护仍可重试空间回收。
 - `GET /plugins/<tag>/stats/plugins`
   - 返回按 `matcher / executor / builtin` 聚合的命中统计。
   - 支持 `since_ms`、`until_ms`、`kind=matcher|executor|builtin|all` 和 records 的过滤参数。

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
@@ -1709,7 +1709,7 @@ Persists the entry request, the post-`next` response, and `sequence` execution-p
 - tag: query_recorder_main
   type: query_recorder
   args:
-    # SQLite path for this recorder. Different recorders should use different paths.
+    # SQLite path for this recorder. Multiple recorders may share one file.
     path: "./data/query-recorder-main.sqlite"
     # Hot-path enqueue buffer size
     queue_size: 8192
@@ -1783,7 +1783,10 @@ Persists the entry request, the post-`next` response, and `sequence` execution-p
   - `qr_<safe_tag>_<fnv64hex>_v1_meta`
 - `records` contains only the fixed schema fields for structured snapshots. `steps` stores `sequence` path events for path analysis and hit-rate reporting. `questions` is a derived index table from `questions_json` for faster qname/qtype queries. `meta` records completed derived-table migrations.
 - Every recorder owns its own bounded queue, SQLite connection, writer thread, tail buffer, and SSE broadcaster.
-- v1 assumes different recorders use different `path` values. There is no cross-recorder writer sharing or path coordination.
+- Recorders that share the same `path` coordinate readers, writers, and maintenance by normalized database path; tables and in-memory state remain isolated by tag.
+- Periodic retention cleanup deletes expired rows, reclaims every completely free page, and truncates the WAL last. The database file shrinks only when deletion produces complete free pages; small deletions may instead leave reusable space inside live pages.
+- If an existing database still uses `auto_vacuum=NONE`, its first periodic or manual cleanup performs one full `VACUUM` to migrate it to `INCREMENTAL`. This may temporarily pause recorder database reads and writes and require additional temporary disk space, but it does not block DNS request processing.
+- A maintenance failure does not stop the writer. Periodic cleanup retries on a later interval and structured logs report page counts, file sizes, and the failure stage.
 
 ### Data Shape
 
@@ -1830,7 +1833,8 @@ Persists the entry request, the post-`next` response, and `sequence` execution-p
   - Returns one full record plus `steps`.
 - `DELETE /plugins/<tag>/records`
   - Clears all history rows and `steps` for the current recorder, and clears the in-memory tail.
-  - The operation first flushes the background writer queue and returns `cleared_records` for the number of deleted main-table rows.
+  - The operation first flushes the background writer queue, then deletes records in small auto-committed batches. It truncates the WAL after every deletion and page-reclamation batch, avoiding one transaction spanning the full clear operation. It returns `cleared_records` for the number of deleted main-table rows.
+  - If history deletion succeeds but disk reclamation fails, the endpoint returns `query_recorder_clear_failed` with a message that history was already cleared; later maintenance can retry space reclamation.
 - `GET /plugins/<tag>/stats/plugins`
   - Returns hit stats grouped by `matcher / executor / builtin`.
   - Supports `since_ms`, `until_ms`, `kind=matcher|executor|builtin|all`, and the record filters.

--- a/src/plugin/executor/query_recorder/api.rs
+++ b/src/plugin/executor/query_recorder/api.rs
@@ -133,8 +133,10 @@ where
         .acquire_owned()
         .await
         .map_err(|err| DnsError::runtime(format!("query_recorder reader closed: {err}")))?;
+    let database_coordinator = backend.database_coordinator.clone();
     tokio::task::spawn_blocking(move || {
         let _permit = permit;
+        let _access = database_coordinator.read_access()?;
         op(backend)
     })
     .await

--- a/src/plugin/executor/query_recorder/backend.rs
+++ b/src/plugin/executor/query_recorder/backend.rs
@@ -1,16 +1,18 @@
 // SPDX-FileCopyrightText: 2025 Sven Shi
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::collections::VecDeque;
-use std::path::PathBuf;
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Sender as ReplySender, SyncSender, sync_channel};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex, MutexGuard, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
+};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::sync::{Semaphore, broadcast};
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 use super::model::{PendingRecord, RecordDetail, ResolvedRecorderConfig, TableNames};
 use super::store::{create_schema, open_writer_database, run_writer_thread, table_names};
@@ -29,13 +31,55 @@ pub(super) struct RecorderBackend {
     pub(super) broadcaster: broadcast::Sender<RecordDetail>,
     pub(super) dropped_total: Arc<AtomicU64>,
     pub(super) reader_semaphore: Arc<Semaphore>,
+    pub(super) database_coordinator: Arc<DatabaseCoordinator>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct SpaceStats {
+    pub(super) auto_vacuum: i64,
+    pub(super) page_size: u64,
+    pub(super) page_count: u64,
+    pub(super) freelist_count: u64,
+    pub(super) database_bytes: u64,
+    pub(super) wal_bytes: u64,
+}
+
+impl SpaceStats {
+    pub(super) fn total_bytes(&self) -> u64 {
+        self.database_bytes.saturating_add(self.wal_bytes)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct SpaceReclaimResult {
+    pub(super) before: SpaceStats,
+    pub(super) reclaimable: SpaceStats,
+    pub(super) after: SpaceStats,
+    pub(super) migrated: bool,
+    pub(super) peak_wal_bytes: u64,
+}
+
+impl SpaceReclaimResult {
+    pub(super) fn reclaimed_bytes(&self) -> u64 {
+        self.before
+            .total_bytes()
+            .saturating_sub(self.after.total_bytes())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct CleanupResult {
+    pub(super) deleted_records: usize,
+    pub(super) space: SpaceReclaimResult,
 }
 
 #[derive(Debug, Clone)]
 pub(super) struct ClearHistoryResult {
     pub(super) cleared_records: usize,
+    pub(super) space: SpaceReclaimResult,
 }
 
+pub(super) type CleanupReply = std::result::Result<CleanupResult, String>;
 pub(super) type ClearHistoryReply = std::result::Result<ClearHistoryResult, String>;
 #[cfg(test)]
 pub(super) type FlushReply = std::result::Result<(), String>;
@@ -45,6 +89,7 @@ pub(super) enum WriterCommand {
     Insert(Box<PendingRecord>),
     Cleanup {
         cutoff_ms: i64,
+        reply_tx: ReplySender<CleanupReply>,
     },
     ClearHistory {
         reply_tx: ReplySender<ClearHistoryReply>,
@@ -57,6 +102,7 @@ pub(super) enum WriterCommand {
 
 #[derive(Debug)]
 pub(super) struct WriterThreadContext {
+    pub(super) path: PathBuf,
     pub(super) tables: TableNames,
     pub(super) stop_requested: Arc<AtomicBool>,
     pub(super) tail: Arc<Mutex<VecDeque<RecordDetail>>>,
@@ -64,6 +110,68 @@ pub(super) struct WriterThreadContext {
     pub(super) broadcaster: broadcast::Sender<RecordDetail>,
     pub(super) batch_size: usize,
     pub(super) flush_interval: Duration,
+    pub(super) database_coordinator: Arc<DatabaseCoordinator>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct DatabaseCoordinator {
+    access: RwLock<()>,
+    writer: Mutex<()>,
+}
+
+impl DatabaseCoordinator {
+    pub(super) fn read_access(&self) -> Result<RwLockReadGuard<'_, ()>> {
+        self.access
+            .read()
+            .map_err(|_| DnsError::runtime("query_recorder database access lock poisoned"))
+    }
+
+    pub(super) fn write_access(&self) -> Result<RwLockWriteGuard<'_, ()>> {
+        self.access
+            .write()
+            .map_err(|_| DnsError::runtime("query_recorder database access lock poisoned"))
+    }
+
+    pub(super) fn writer(&self) -> Result<MutexGuard<'_, ()>> {
+        self.writer
+            .lock()
+            .map_err(|_| DnsError::runtime("query_recorder database writer lock poisoned"))
+    }
+}
+
+static DATABASE_COORDINATORS: OnceLock<Mutex<HashMap<PathBuf, Weak<DatabaseCoordinator>>>> =
+    OnceLock::new();
+
+fn database_coordinator(path: &Path) -> Result<Arc<DatabaseCoordinator>> {
+    let path = canonical_database_path(path)?;
+    let registry = DATABASE_COORDINATORS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut registry = registry
+        .lock()
+        .map_err(|_| DnsError::runtime("query_recorder coordinator registry lock poisoned"))?;
+    registry.retain(|_, coordinator| coordinator.strong_count() > 0);
+    if let Some(coordinator) = registry.get(&path).and_then(Weak::upgrade) {
+        return Ok(coordinator);
+    }
+    let coordinator = Arc::new(DatabaseCoordinator::default());
+    registry.insert(path, Arc::downgrade(&coordinator));
+    Ok(coordinator)
+}
+
+fn canonical_database_path(path: &Path) -> Result<PathBuf> {
+    if path.exists() {
+        return Ok(std::fs::canonicalize(path)?);
+    }
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    let canonical_parent = match parent {
+        Some(parent) => std::fs::canonicalize(parent)?,
+        None => std::env::current_dir()?,
+    };
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| DnsError::plugin("query_recorder path must include a file name"))?;
+    Ok(canonical_parent.join(file_name))
 }
 
 impl RecorderBackend {
@@ -80,22 +188,27 @@ impl RecorderBackend {
             })?;
         }
 
-        let mut conn = open_writer_database(&config.path).map_err(|err| {
-            format!(
-                "failed to open database '{}': {}",
-                config.path.display(),
-                err
-            )
-        })?;
+        let database_coordinator = database_coordinator(&config.path)?;
+        let (conn, tables) = {
+            let _access = database_coordinator.write_access()?;
+            let mut conn = open_writer_database(&config.path).map_err(|err| {
+                format!(
+                    "failed to open database '{}': {}",
+                    config.path.display(),
+                    err
+                )
+            })?;
 
-        let tables = table_names(&tag);
-        create_schema(&mut conn, &tables)?;
-        // Refresh query planner stats once at startup; this is the cheap
-        // version of ANALYZE and is the recommended way to keep indexes
-        // selectable across schema upgrades.
-        if let Err(err) = conn.execute_batch("PRAGMA optimize;") {
-            warn!("query_recorder PRAGMA optimize failed at startup: {}", err);
-        }
+            let tables = table_names(&tag);
+            create_schema(&mut conn, &tables)?;
+            // Refresh query planner stats once at startup; this is the cheap
+            // version of ANALYZE and is the recommended way to keep indexes
+            // selectable across schema upgrades.
+            if let Err(err) = conn.execute_batch("PRAGMA optimize;") {
+                warn!("query_recorder PRAGMA optimize failed at startup: {}", err);
+            }
+            (conn, tables)
+        };
 
         let (queue_tx, queue_rx) = sync_channel(config.queue_size);
         let stop_requested = Arc::new(AtomicBool::new(false));
@@ -107,17 +220,20 @@ impl RecorderBackend {
         let reader_semaphore = Arc::new(Semaphore::new(config.reader_concurrency));
 
         let writer_tables = tables.clone();
+        let writer_path = config.path.clone();
         let writer_stop = stop_requested.clone();
         let writer_tail = tail.clone();
         let writer_broadcaster = broadcaster.clone();
         let memory_tail = config.memory_tail.max(1);
         let batch_size = config.batch_size;
         let flush_interval = Duration::from_millis(config.flush_interval_ms);
+        let writer_database_coordinator = database_coordinator.clone();
         let writer_handle = thread::Builder::new()
             .name(format!("query-recorder-{}", tag))
             .spawn(move || {
                 if let Err(err) = run_writer_thread(
                     WriterThreadContext {
+                        path: writer_path,
                         tables: writer_tables,
                         stop_requested: writer_stop,
                         tail: writer_tail,
@@ -125,6 +241,7 @@ impl RecorderBackend {
                         broadcaster: writer_broadcaster,
                         batch_size,
                         flush_interval,
+                        database_coordinator: writer_database_coordinator,
                     },
                     queue_rx,
                     conn,
@@ -145,6 +262,7 @@ impl RecorderBackend {
             broadcaster,
             dropped_total,
             reader_semaphore,
+            database_coordinator,
         }))
     }
 
@@ -158,20 +276,49 @@ impl RecorderBackend {
         }
     }
 
-    pub(super) fn cleanup(&self, cutoff_ms: i64) {
-        if let Err(err) = self.queue_tx.try_send(WriterCommand::Cleanup { cutoff_ms }) {
-            warn!("query_recorder cleanup skipped: {}", err);
+    pub(super) fn cleanup(&self, cutoff_ms: i64) -> CleanupReply {
+        let started = Instant::now();
+        let (reply_tx, reply_rx) = std::sync::mpsc::channel();
+        self.queue_tx
+            .send(WriterCommand::Cleanup {
+                cutoff_ms,
+                reply_tx,
+            })
+            .map_err(|err| format!("query_recorder cleanup enqueue failed: {err}"))?;
+        let result = reply_rx
+            .recv()
+            .map_err(|err| format!("query_recorder cleanup reply failed: {err}"))?;
+        if let Ok(result) = &result {
+            log_space_reclaim(
+                &self.tag,
+                "periodic",
+                result.deleted_records,
+                &result.space,
+                started.elapsed(),
+            );
         }
+        result
     }
 
     pub(super) fn clear_history(&self) -> ClearHistoryReply {
+        let started = Instant::now();
         let (reply_tx, reply_rx) = std::sync::mpsc::channel();
         self.queue_tx
             .send(WriterCommand::ClearHistory { reply_tx })
             .map_err(|err| format!("query_recorder clear enqueue failed: {err}"))?;
-        reply_rx
+        let result = reply_rx
             .recv()
-            .map_err(|err| format!("query_recorder clear reply failed: {err}"))?
+            .map_err(|err| format!("query_recorder clear reply failed: {err}"))?;
+        if let Ok(result) = &result {
+            log_space_reclaim(
+                &self.tag,
+                "manual",
+                result.cleared_records,
+                &result.space,
+                started.elapsed(),
+            );
+        }
+        result
     }
 
     #[cfg(test)]
@@ -184,4 +331,36 @@ impl RecorderBackend {
             .recv()
             .map_err(|err| format!("query_recorder flush reply failed: {err}"))?
     }
+}
+
+fn log_space_reclaim(
+    tag: &str,
+    operation: &str,
+    deleted_records: usize,
+    space: &SpaceReclaimResult,
+    elapsed: Duration,
+) {
+    info!(
+        query_recorder_tag = tag,
+        operation,
+        deleted_records,
+        migrated = space.migrated,
+        auto_vacuum_before = space.reclaimable.auto_vacuum,
+        auto_vacuum_after = space.after.auto_vacuum,
+        page_size = space.after.page_size,
+        page_count_before = space.before.page_count,
+        page_count_reclaimable = space.reclaimable.page_count,
+        page_count_after = space.after.page_count,
+        freelist_before = space.before.freelist_count,
+        freelist_reclaimable = space.reclaimable.freelist_count,
+        freelist_after = space.after.freelist_count,
+        database_bytes_before = space.before.database_bytes,
+        database_bytes_after = space.after.database_bytes,
+        wal_bytes_before = space.before.wal_bytes,
+        wal_bytes_peak = space.peak_wal_bytes,
+        wal_bytes_after = space.after.wal_bytes,
+        reclaimed_bytes = space.reclaimed_bytes(),
+        elapsed_ms = elapsed.as_millis(),
+        "query_recorder space reclaim completed"
+    );
 }

--- a/src/plugin/executor/query_recorder/mod.rs
+++ b/src/plugin/executor/query_recorder/mod.rs
@@ -12,6 +12,8 @@
 //!   `next`;
 //! - each recorder owns its own queue, SQLite connection, writer thread, tail
 //!   buffer, and SSE broadcaster;
+//! - recorders sharing a database path coordinate reads, writes, and
+//!   maintenance;
 //! - persistence uses one `records` table and one `steps` table per recorder
 //!   schema version.
 
@@ -32,6 +34,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use jiff::Timestamp;
 use serde_yaml_ng::Value as YamlValue;
+use tracing::warn;
 
 use self::backend::RecorderBackend;
 use self::model::{PendingRecord, QueryRecorderConfig, ResolvedRecorderConfig};
@@ -79,7 +82,14 @@ impl Plugin for QueryRecorder {
             move || {
                 let recorder_backend = recorder_backend.clone();
                 async move {
-                    recorder_backend.cleanup(Timestamp::now().as_millisecond() - retention_ms);
+                    let cutoff_ms = Timestamp::now().as_millisecond() - retention_ms;
+                    match tokio::task::spawn_blocking(move || recorder_backend.cleanup(cutoff_ms))
+                        .await
+                    {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(err)) => warn!("query_recorder cleanup failed: {}", err),
+                        Err(err) => warn!("query_recorder cleanup task failed: {}", err),
+                    }
                 }
             },
         ));

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -658,11 +658,24 @@ fn run_clear_history(
     tables: &TableNames,
     tail: &Arc<Mutex<VecDeque<RecordDetail>>>,
 ) -> Result<ClearHistoryResult> {
+    run_clear_history_with_checkpoint(conn, path, tables, tail, &mut checkpoint_wal)
+}
+
+fn run_clear_history_with_checkpoint<F>(
+    conn: &mut Connection,
+    path: &Path,
+    tables: &TableNames,
+    tail: &Arc<Mutex<VecDeque<RecordDetail>>>,
+    checkpoint: &mut F,
+) -> Result<ClearHistoryResult>
+where
+    F: FnMut(&Connection) -> Result<()>,
+{
     // Start from an empty WAL and keep it bounded throughout the operation.
     // A single DELETE transaction for a large recorder can otherwise grow the
     // WAL close to the amount of history being removed before the final
     // checkpoint gets a chance to truncate it.
-    checkpoint_wal(conn)?;
+    checkpoint(conn)?;
     let before = read_space_stats(conn, path)?;
     let mut cleared_records = 0usize;
     let mut peak_wal_bytes = 0;
@@ -683,15 +696,15 @@ fn run_clear_history(
             break;
         }
         cleared_records = cleared_records.saturating_add(deleted);
+        // Deletes are auto-committed per batch. Clear the in-memory replay
+        // buffer before the next fallible checkpoint so a partial clear can
+        // never advertise rows that no longer exist in SQLite.
+        clear_tail(tail);
         observe_wal_size(path, &mut peak_wal_bytes)?;
-        checkpoint_wal(conn)?;
+        checkpoint(conn)?;
     }
 
-    let mut tail_guard = tail
-        .lock()
-        .map_err(|_| "query_recorder tail buffer lock poisoned".to_string())?;
-    tail_guard.clear();
-    drop(tail_guard);
+    clear_tail(tail);
 
     let reclaimable = read_space_stats(conn, path)?;
     let space =
@@ -705,6 +718,11 @@ fn run_clear_history(
         cleared_records,
         space,
     })
+}
+
+fn clear_tail(tail: &Arc<Mutex<VecDeque<RecordDetail>>>) {
+    let mut tail_guard = tail.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    tail_guard.clear();
 }
 
 fn reclaim_database_space(
@@ -1807,6 +1825,10 @@ fn non_negative_usize(value: i64) -> rusqlite::Result<usize> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::path::Path;
+    use std::sync::{Arc, Mutex};
+
     use rusqlite::{Connection, params};
     use serde_json::json;
 
@@ -1912,6 +1934,57 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM questions", [], |row| row.get(0))
             .unwrap();
         assert_eq!(question_count, 0);
+    }
+
+    #[test]
+    fn test_clear_history_clears_tail_before_partial_batch_checkpoint_failure() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let tables = TableNames {
+            records: "records".to_string(),
+            steps: "steps".to_string(),
+            questions: "questions".to_string(),
+            meta: "meta".to_string(),
+        };
+        create_schema(&mut conn, &tables).unwrap();
+
+        let tx = conn.transaction().unwrap();
+        let mut first_detail = None;
+        for request_id in 0..=CLEANUP_BATCH_SIZE {
+            let mut record = sample_record_row();
+            record.request_id = request_id as u16;
+            let detail = insert_record(&tx, &tables, record, Vec::new()).unwrap();
+            if first_detail.is_none() {
+                first_detail = Some(detail);
+            }
+        }
+        tx.commit().unwrap();
+
+        let tail = Arc::new(Mutex::new(VecDeque::from([first_detail.unwrap()])));
+        let checkpoint_calls = Cell::new(0);
+        let mut checkpoint = |_: &Connection| {
+            let calls = checkpoint_calls.get() + 1;
+            checkpoint_calls.set(calls);
+            if calls == 2 {
+                Err(DnsError::runtime("injected checkpoint failure"))
+            } else {
+                Ok(())
+            }
+        };
+
+        let result = run_clear_history_with_checkpoint(
+            &mut conn,
+            Path::new("/nonexistent/query-recorder-review.sqlite"),
+            &tables,
+            &tail,
+            &mut checkpoint,
+        );
+
+        assert!(result.is_err());
+        assert!(tail.lock().unwrap().is_empty());
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM records", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(remaining, 1);
     }
 
     fn sample_record_row() -> RecordRow {

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use std::collections::VecDeque;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
@@ -13,7 +13,10 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::sync::broadcast;
 
-use super::backend::{ClearHistoryResult, RecorderBackend, WriterCommand, WriterThreadContext};
+use super::backend::{
+    CleanupResult, ClearHistoryResult, DatabaseCoordinator, RecorderBackend, SpaceReclaimResult,
+    SpaceStats, WriterCommand, WriterThreadContext,
+};
 use super::model::{
     DistributionQuery, DistributionResponse, DistributionRow, LatencyHistogramBucket, LatencyQuery,
     LatencySlowRow, LatencySummary, ListCursor, ListQuery, PendingRecord, PluginStatsKind,
@@ -26,6 +29,7 @@ use crate::infra::error::{DnsError, Result};
 const SCHEMA_VERSION: &str = "v1";
 const QUESTIONS_BACKFILL_MARKER: &str = "questions_backfilled";
 const CLEANUP_BATCH_SIZE: usize = 1_000;
+const VACUUM_BATCH_PAGES: u64 = 1_000;
 const PLUGIN_STATS_SAMPLE_LIMIT: usize = 10_000;
 const RECORD_ROW_COLUMNS: [&str; 27] = [
     "id",
@@ -305,6 +309,7 @@ pub(super) fn run_writer_thread(
     mut conn: Connection,
 ) -> Result<()> {
     let WriterThreadContext {
+        path,
         tables,
         stop_requested,
         tail,
@@ -312,6 +317,7 @@ pub(super) fn run_writer_thread(
         broadcaster,
         batch_size,
         flush_interval,
+        database_coordinator,
     } = context;
 
     let mut pending = Vec::with_capacity(batch_size);
@@ -320,6 +326,23 @@ pub(super) fn run_writer_thread(
             Ok(WriterCommand::Insert(record)) => {
                 pending.push(*record);
                 if pending.len() >= batch_size {
+                    flush_pending_coordinated(
+                        &mut conn,
+                        &tables,
+                        &mut pending,
+                        &tail,
+                        memory_tail,
+                        &broadcaster,
+                        &database_coordinator,
+                    )?;
+                }
+            }
+            Ok(WriterCommand::Cleanup {
+                cutoff_ms,
+                reply_tx,
+            }) => {
+                let result = (|| {
+                    let _access = database_coordinator.write_access()?;
                     flush_pending(
                         &mut conn,
                         &tables,
@@ -328,66 +351,64 @@ pub(super) fn run_writer_thread(
                         memory_tail,
                         &broadcaster,
                     )?;
-                }
-            }
-            Ok(WriterCommand::Cleanup { cutoff_ms }) => {
-                flush_pending(
-                    &mut conn,
-                    &tables,
-                    &mut pending,
-                    &tail,
-                    memory_tail,
-                    &broadcaster,
-                )?;
-                run_cleanup(&mut conn, &tables, cutoff_ms)?;
+                    run_cleanup(&mut conn, &path, &tables, cutoff_ms)
+                })()
+                .map_err(|err: DnsError| err.to_string());
+                let _ = reply_tx.send(result);
             }
             Ok(WriterCommand::ClearHistory { reply_tx }) => {
-                let result = flush_pending(
-                    &mut conn,
-                    &tables,
-                    &mut pending,
-                    &tail,
-                    memory_tail,
-                    &broadcaster,
-                )
-                .and_then(|_| run_clear_history(&mut conn, &tables, &tail))
-                .map_err(|err| err.to_string());
+                let result = (|| {
+                    let _access = database_coordinator.write_access()?;
+                    flush_pending(
+                        &mut conn,
+                        &tables,
+                        &mut pending,
+                        &tail,
+                        memory_tail,
+                        &broadcaster,
+                    )?;
+                    run_clear_history(&mut conn, &path, &tables, &tail)
+                })()
+                .map_err(|err: DnsError| err.to_string());
                 let _ = reply_tx.send(result);
             }
             #[cfg(test)]
             Ok(WriterCommand::Flush { reply_tx }) => {
-                let result = flush_pending(
+                let result = flush_pending_coordinated(
                     &mut conn,
                     &tables,
                     &mut pending,
                     &tail,
                     memory_tail,
                     &broadcaster,
+                    &database_coordinator,
                 )
                 .map_err(|err| err.to_string());
                 let _ = reply_tx.send(result);
             }
             Err(RecvTimeoutError::Timeout) => {
-                flush_pending(
+                flush_pending_coordinated(
                     &mut conn,
                     &tables,
                     &mut pending,
                     &tail,
                     memory_tail,
                     &broadcaster,
+                    &database_coordinator,
                 )?;
                 if stop_requested.load(Ordering::Relaxed) {
                     break;
                 }
             }
             Err(RecvTimeoutError::Disconnected) => {
-                flush_pending(
+                flush_pending_coordinated(
                     &mut conn,
                     &tables,
                     &mut pending,
                     &tail,
                     memory_tail,
                     &broadcaster,
+                    &database_coordinator,
                 )?;
                 break;
             }
@@ -395,6 +416,20 @@ pub(super) fn run_writer_thread(
     }
 
     Ok(())
+}
+
+fn flush_pending_coordinated(
+    conn: &mut Connection,
+    tables: &TableNames,
+    pending: &mut Vec<PendingRecord>,
+    tail: &Arc<Mutex<VecDeque<RecordDetail>>>,
+    memory_tail: usize,
+    broadcaster: &broadcast::Sender<RecordDetail>,
+    database_coordinator: &DatabaseCoordinator,
+) -> Result<()> {
+    let _access = database_coordinator.read_access()?;
+    let _writer = database_coordinator.writer()?;
+    flush_pending(conn, tables, pending, tail, memory_tail, broadcaster)
 }
 
 fn flush_pending(
@@ -578,7 +613,16 @@ where
         .transpose()
 }
 
-fn run_cleanup(conn: &mut Connection, tables: &TableNames, cutoff_ms: i64) -> rusqlite::Result<()> {
+fn run_cleanup(
+    conn: &mut Connection,
+    path: &Path,
+    tables: &TableNames,
+    cutoff_ms: i64,
+) -> Result<CleanupResult> {
+    checkpoint_wal(conn)?;
+    let before = read_space_stats(conn, path)?;
+    let mut deleted_records = 0usize;
+    let mut peak_wal_bytes = 0;
     loop {
         let deleted = conn.execute(
             &format!(
@@ -596,26 +640,213 @@ fn run_cleanup(conn: &mut Connection, tables: &TableNames, cutoff_ms: i64) -> ru
         if deleted == 0 {
             break;
         }
+        deleted_records = deleted_records.saturating_add(deleted);
+        observe_wal_size(path, &mut peak_wal_bytes)?;
+        checkpoint_wal(conn)?;
     }
-    conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE); PRAGMA incremental_vacuum;")
+    let reclaimable = read_space_stats(conn, path)?;
+    let space = reclaim_database_space(conn, path, before, reclaimable, peak_wal_bytes)?;
+    Ok(CleanupResult {
+        deleted_records,
+        space,
+    })
 }
 
 fn run_clear_history(
     conn: &mut Connection,
+    path: &Path,
     tables: &TableNames,
     tail: &Arc<Mutex<VecDeque<RecordDetail>>>,
 ) -> Result<ClearHistoryResult> {
-    let tx = conn.transaction()?;
-    let cleared_records = tx.execute(&format!("DELETE FROM {}", tables.records), [])?;
-    tx.commit()?;
-    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA incremental_vacuum;")?;
+    // Start from an empty WAL and keep it bounded throughout the operation.
+    // A single DELETE transaction for a large recorder can otherwise grow the
+    // WAL close to the amount of history being removed before the final
+    // checkpoint gets a chance to truncate it.
+    checkpoint_wal(conn)?;
+    let before = read_space_stats(conn, path)?;
+    let mut cleared_records = 0usize;
+    let mut peak_wal_bytes = 0;
+    loop {
+        let deleted = conn.execute(
+            &format!(
+                "DELETE FROM {records}
+                 WHERE id IN (
+                    SELECT id FROM {records}
+                    ORDER BY id ASC
+                    LIMIT ?1
+                 )",
+                records = tables.records
+            ),
+            params![CLEANUP_BATCH_SIZE as i64],
+        )?;
+        if deleted == 0 {
+            break;
+        }
+        cleared_records = cleared_records.saturating_add(deleted);
+        observe_wal_size(path, &mut peak_wal_bytes)?;
+        checkpoint_wal(conn)?;
+    }
 
     let mut tail_guard = tail
         .lock()
         .map_err(|_| "query_recorder tail buffer lock poisoned".to_string())?;
     tail_guard.clear();
+    drop(tail_guard);
 
-    Ok(ClearHistoryResult { cleared_records })
+    let reclaimable = read_space_stats(conn, path)?;
+    let space =
+        reclaim_database_space(conn, path, before, reclaimable, peak_wal_bytes).map_err(|err| {
+            DnsError::runtime(format!(
+                "query history cleared ({cleared_records} records), but space reclaim failed: {err}"
+            ))
+        })?;
+
+    Ok(ClearHistoryResult {
+        cleared_records,
+        space,
+    })
+}
+
+fn reclaim_database_space(
+    conn: &Connection,
+    path: &Path,
+    before: SpaceStats,
+    reclaimable: SpaceStats,
+    mut peak_wal_bytes: u64,
+) -> Result<SpaceReclaimResult> {
+    let migrated = match reclaimable.auto_vacuum {
+        0 => {
+            conn.execute_batch("PRAGMA auto_vacuum=INCREMENTAL; VACUUM;")?;
+            true
+        }
+        1 => false,
+        2 => {
+            run_incremental_vacuum(conn, path, &mut peak_wal_bytes)?;
+            false
+        }
+        mode => {
+            return Err(DnsError::runtime(format!(
+                "query_recorder returned unsupported auto_vacuum mode {mode}"
+            )));
+        }
+    };
+
+    observe_wal_size(path, &mut peak_wal_bytes)?;
+    checkpoint_wal(conn)?;
+
+    let after = read_space_stats(conn, path)?;
+    if migrated && after.auto_vacuum != 2 {
+        return Err(DnsError::runtime(format!(
+            "query_recorder legacy database migration did not enable incremental auto-vacuum (mode {})",
+            after.auto_vacuum
+        )));
+    }
+    if after.freelist_count != 0 {
+        return Err(DnsError::runtime(format!(
+            "query_recorder space reclaim left {} free pages",
+            after.freelist_count
+        )));
+    }
+    if reclaimable.freelist_count > 0 && after.page_count >= reclaimable.page_count {
+        return Err(DnsError::runtime(format!(
+            "query_recorder space reclaim made no page-count progress ({} pages, {} free)",
+            after.page_count, reclaimable.freelist_count
+        )));
+    }
+
+    Ok(SpaceReclaimResult {
+        before,
+        reclaimable,
+        after,
+        migrated,
+        peak_wal_bytes,
+    })
+}
+
+fn run_incremental_vacuum(conn: &Connection, path: &Path, peak_wal_bytes: &mut u64) -> Result<()> {
+    // `PRAGMA incremental_vacuum` is a multi-step statement that yields one
+    // zero-column row per reclaimed page. `Connection::execute_batch` only
+    // steps a result-producing statement once. Reclaim a bounded number of
+    // pages per statement and truncate the WAL between batches so a manual
+    // clear cannot trade a smaller main file for an unbounded WAL peak.
+    loop {
+        let before = pragma_u64(conn, "PRAGMA freelist_count")?;
+        if before == 0 {
+            return Ok(());
+        }
+
+        let mut statement =
+            conn.prepare(&format!("PRAGMA incremental_vacuum({VACUUM_BATCH_PAGES})"))?;
+        let mut rows = statement.query([])?;
+        while rows.next()?.is_some() {}
+        drop(rows);
+        drop(statement);
+        observe_wal_size(path, peak_wal_bytes)?;
+        checkpoint_wal(conn)?;
+
+        let after = pragma_u64(conn, "PRAGMA freelist_count")?;
+        if after >= before {
+            return Err(DnsError::runtime(format!(
+                "query_recorder incremental vacuum made no progress ({after} of {before} free pages remain)"
+            )));
+        }
+    }
+}
+
+fn checkpoint_wal(conn: &Connection) -> Result<()> {
+    let (busy, _log_frames, _checkpointed_frames) =
+        conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        })?;
+    if busy != 0 {
+        return Err(DnsError::runtime(format!(
+            "query_recorder WAL checkpoint remained busy ({busy})"
+        )));
+    }
+    Ok(())
+}
+
+fn observe_wal_size(path: &Path, peak_wal_bytes: &mut u64) -> Result<()> {
+    *peak_wal_bytes = (*peak_wal_bytes).max(file_size(&wal_path(path))?);
+    Ok(())
+}
+
+fn read_space_stats(conn: &Connection, path: &Path) -> Result<SpaceStats> {
+    let auto_vacuum = conn.query_row("PRAGMA auto_vacuum", [], |row| row.get::<_, i64>(0))?;
+    let page_size = pragma_u64(conn, "PRAGMA page_size")?;
+    let page_count = pragma_u64(conn, "PRAGMA page_count")?;
+    let freelist_count = pragma_u64(conn, "PRAGMA freelist_count")?;
+    Ok(SpaceStats {
+        auto_vacuum,
+        page_size,
+        page_count,
+        freelist_count,
+        database_bytes: file_size(path)?,
+        wal_bytes: file_size(&wal_path(path))?,
+    })
+}
+
+fn pragma_u64(conn: &Connection, pragma: &str) -> Result<u64> {
+    let value = conn.query_row(pragma, [], |row| row.get::<_, i64>(0))?;
+    non_negative_u64(value).map_err(Into::into)
+}
+
+fn file_size(path: &Path) -> Result<u64> {
+    match std::fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.len()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(0),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn wal_path(path: &Path) -> PathBuf {
+    let mut path = path.as_os_str().to_os_string();
+    path.push("-wal");
+    PathBuf::from(path)
 }
 
 pub(super) fn query_records(

--- a/src/plugin/executor/query_recorder/tests.rs
+++ b/src/plugin/executor/query_recorder/tests.rs
@@ -4,8 +4,10 @@
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::atomic::Ordering;
 
+use rusqlite::Connection;
 use tempfile::NamedTempFile;
 
+use super::backend::WriterCommand;
 use super::model::{
     DistributionQuery, LatencyQuery, ListQuery, PendingRecord, PluginStatsKind, PluginsStatsQuery,
     QueryRecordFilter, QueryRecordStatus, QueryRecorderConfig, TimeseriesBucket, TimeseriesQuery,
@@ -31,6 +33,20 @@ fn recorder_config(path: &str) -> serde_yaml_ng::Value {
         path: path.to_string(),
         queue_size: Some(32),
         batch_size: Some(1),
+        flush_interval_ms: Some(10),
+        memory_tail: Some(16),
+        retention_days: Some(7),
+        cleanup_interval_hours: Some(1),
+        reader_concurrency: Some(2),
+    })
+    .unwrap()
+}
+
+fn recorder_space_config(path: &str) -> serde_yaml_ng::Value {
+    serde_yaml_ng::to_value(QueryRecorderConfig {
+        path: path.to_string(),
+        queue_size: Some(4_096),
+        batch_size: Some(256),
         flush_interval_ms: Some(10),
         memory_tail: Some(16),
         retention_days: Some(7),
@@ -68,6 +84,38 @@ async fn flush_backend(backend: &std::sync::Arc<super::backend::RecorderBackend>
         .await
         .unwrap()
         .unwrap();
+}
+
+async fn seed_bulk_records(
+    backend: &std::sync::Arc<super::backend::RecorderBackend>,
+    count: usize,
+) {
+    for index in 0..count {
+        backend.enqueue(pending_record(
+            index as i64,
+            index as u16,
+            "space-reclaim.example.com.",
+            RecordType::A,
+            Ipv4Addr::new(192, 0, 2, 1),
+            Some(Rcode::NoError),
+            None,
+            &[("matcher_for_space_reclaim", "matched")],
+        ));
+    }
+    flush_backend(backend).await;
+}
+
+fn prepare_legacy_database(path: &std::path::Path) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         CREATE TABLE legacy_marker (id INTEGER PRIMARY KEY);",
+    )
+    .unwrap();
+    let mode: i64 = conn
+        .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(mode, 0);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -453,6 +501,352 @@ async fn test_query_recorder_clear_history_does_not_wait_for_reader_permits() {
 
     assert_eq!(clear_result.cleared_records, 5);
     assert!(backend.tail.lock().unwrap().is_empty());
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_periodic_cleanup_reclaims_database_and_wal_space() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_space_config(
+        &temp.path().display().to_string(),
+    )))
+    .unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+
+    seed_bulk_records(&backend, 2_000).await;
+    let cleanup_backend = backend.clone();
+    let result = tokio::task::spawn_blocking(move || cleanup_backend.cleanup(i64::MAX))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.deleted_records, 2_000);
+    assert!(!result.space.migrated);
+    assert_eq!(result.space.after.auto_vacuum, 2);
+    assert_eq!(result.space.after.freelist_count, 0);
+    assert_eq!(result.space.after.wal_bytes, 0);
+    assert!(result.space.peak_wal_bytes > 0);
+    assert!(result.space.reclaimable.freelist_count > 0);
+    assert!(result.space.after.page_count < result.space.reclaimable.page_count);
+    assert!(result.space.after.total_bytes() < result.space.before.total_bytes());
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_manual_clear_reclaims_database_and_wal_space() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_space_config(
+        &temp.path().display().to_string(),
+    )))
+    .unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+
+    seed_bulk_records(&backend, 2_000).await;
+    let clear_backend = backend.clone();
+    let result = tokio::task::spawn_blocking(move || clear_backend.clear_history())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.cleared_records, 2_000);
+    assert_eq!(result.space.after.freelist_count, 0);
+    assert_eq!(result.space.after.wal_bytes, 0);
+    assert!(result.space.peak_wal_bytes > 0);
+    assert!(result.space.reclaimable.freelist_count > 0);
+    assert!(result.space.after.page_count < result.space.reclaimable.page_count);
+    assert!(result.space.after.total_bytes() < result.space.before.total_bytes());
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_periodic_cleanup_migrates_legacy_database() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    prepare_legacy_database(temp.path());
+    let config = resolve_config(Some(recorder_space_config(
+        &temp.path().display().to_string(),
+    )))
+    .unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+
+    seed_bulk_records(&backend, 1_000).await;
+    let cleanup_backend = backend.clone();
+    let result = tokio::task::spawn_blocking(move || cleanup_backend.cleanup(i64::MAX))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.deleted_records, 1_000);
+    assert!(result.space.migrated);
+    assert_eq!(result.space.reclaimable.auto_vacuum, 0);
+    assert_eq!(result.space.after.auto_vacuum, 2);
+    assert_eq!(result.space.after.freelist_count, 0);
+    assert_eq!(result.space.after.wal_bytes, 0);
+    assert!(result.space.after.page_count < result.space.reclaimable.page_count);
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_manual_clear_migrates_legacy_database() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    prepare_legacy_database(temp.path());
+    let config = resolve_config(Some(recorder_space_config(
+        &temp.path().display().to_string(),
+    )))
+    .unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+
+    seed_bulk_records(&backend, 1_000).await;
+    let clear_backend = backend.clone();
+    let result = tokio::task::spawn_blocking(move || clear_backend.clear_history())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.cleared_records, 1_000);
+    assert!(result.space.migrated);
+    assert_eq!(result.space.after.auto_vacuum, 2);
+    assert_eq!(result.space.after.freelist_count, 0);
+    assert_eq!(result.space.after.wal_bytes, 0);
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_clear_waits_for_active_database_reader() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+    seed_demo_records(&backend).await;
+
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let coordinator = backend.database_coordinator.clone();
+    let reader = std::thread::spawn(move || {
+        let _access = coordinator.read_access().unwrap();
+        ready_tx.send(()).unwrap();
+        release_rx.recv().unwrap();
+    });
+    ready_rx.recv().unwrap();
+
+    let clear_backend = backend.clone();
+    let mut clear_task = tokio::task::spawn_blocking(move || clear_backend.clear_history());
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut clear_task)
+            .await
+            .is_err()
+    );
+
+    release_tx.send(()).unwrap();
+    reader.join().unwrap();
+    let result = tokio::time::timeout(std::time::Duration::from_secs(2), clear_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.cleared_records, 5);
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_shared_database_clear_preserves_other_recorder() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin_a = QueryRecorder::new("rec-a".to_string(), config.clone());
+    let mut plugin_b = QueryRecorder::new("rec-b".to_string(), config);
+    plugin_a.init_for_test().await.unwrap();
+    plugin_b.init_for_test().await.unwrap();
+    let backend_a = plugin_a.backend.as_ref().unwrap().clone();
+    let backend_b = plugin_b.backend.as_ref().unwrap().clone();
+
+    backend_a.enqueue(pending_record(
+        1_000,
+        1,
+        "a.example.com.",
+        RecordType::A,
+        Ipv4Addr::new(192, 0, 2, 1),
+        Some(Rcode::NoError),
+        None,
+        &[],
+    ));
+    backend_b.enqueue(pending_record(
+        2_000,
+        2,
+        "b.example.com.",
+        RecordType::A,
+        Ipv4Addr::new(192, 0, 2, 2),
+        Some(Rcode::NoError),
+        None,
+        &[],
+    ));
+    flush_backend(&backend_a).await;
+    flush_backend(&backend_b).await;
+
+    let clear_backend = backend_a.clone();
+    tokio::task::spawn_blocking(move || clear_backend.clear_history())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert!(
+        query_records(backend_a, list_query(QueryRecordFilter::default()))
+            .unwrap()
+            .0
+            .is_empty()
+    );
+    let records = query_records(backend_b, list_query(QueryRecordFilter::default()))
+        .unwrap()
+        .0;
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].request_id, 2);
+
+    plugin_b.destroy().await.unwrap();
+    plugin_a.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_cleanup_failure_does_not_stop_writer() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+    seed_demo_records(&backend).await;
+
+    let blocker = Connection::open(temp.path()).unwrap();
+    blocker.execute_batch("BEGIN IMMEDIATE;").unwrap();
+    let cleanup_backend = backend.clone();
+    let result = tokio::task::spawn_blocking(move || cleanup_backend.cleanup(i64::MAX))
+        .await
+        .unwrap();
+    assert!(result.is_err());
+    blocker.execute_batch("ROLLBACK;").unwrap();
+
+    backend.enqueue(pending_record(
+        10_000,
+        10,
+        "after-error.example.com.",
+        RecordType::A,
+        Ipv4Addr::new(192, 0, 2, 10),
+        Some(Rcode::NoError),
+        None,
+        &[],
+    ));
+    flush_backend(&backend).await;
+    let records = query_records(backend.clone(), list_query(QueryRecordFilter::default()))
+        .unwrap()
+        .0;
+    assert_eq!(records.len(), 6);
+    assert!(records.iter().any(|record| record.request_id == 10));
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_cleanup_is_not_skipped_when_record_queue_is_full() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(
+        serde_yaml_ng::to_value(QueryRecorderConfig {
+            path: temp.path().display().to_string(),
+            queue_size: Some(1),
+            batch_size: Some(1),
+            flush_interval_ms: Some(10),
+            memory_tail: Some(8),
+            retention_days: Some(7),
+            cleanup_interval_hours: Some(1),
+            reader_concurrency: Some(2),
+        })
+        .unwrap(),
+    ))
+    .unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let coordinator = backend.database_coordinator.clone();
+    let maintenance_holder = std::thread::spawn(move || {
+        let _access = coordinator.write_access().unwrap();
+        ready_tx.send(()).unwrap();
+        release_rx.recv().unwrap();
+    });
+    ready_rx.recv().unwrap();
+
+    let mut queue_was_full = false;
+    for request_id in 1..=16 {
+        let record = pending_record(
+            i64::from(request_id),
+            request_id,
+            "queue-full.example.com.",
+            RecordType::A,
+            Ipv4Addr::new(192, 0, 2, 1),
+            Some(Rcode::NoError),
+            None,
+            &[],
+        );
+        match backend
+            .queue_tx
+            .try_send(WriterCommand::Insert(Box::new(record)))
+        {
+            Ok(()) => std::thread::yield_now(),
+            Err(std::sync::mpsc::TrySendError::Full(_)) => {
+                queue_was_full = true;
+                break;
+            }
+            Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                panic!("query_recorder writer unexpectedly disconnected")
+            }
+        }
+    }
+    assert!(queue_was_full);
+
+    let cleanup_backend = backend.clone();
+    let mut cleanup_task = tokio::task::spawn_blocking(move || cleanup_backend.cleanup(i64::MAX));
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut cleanup_task)
+            .await
+            .is_err()
+    );
+
+    release_tx.send(()).unwrap();
+    maintenance_holder.join().unwrap();
+    let result = tokio::time::timeout(std::time::Duration::from_secs(2), cleanup_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.deleted_records > 0);
 
     plugin.destroy().await.unwrap();
 }


### PR DESCRIPTION
- Introduced a `DatabaseCoordinator` to manage read and write access for recorders sharing the same SQLite database path.
- Updated cleanup and clear history operations to reclaim database and WAL space effectively, including migration from legacy databases.
- Implemented periodic cleanup that deletes expired records and performs space reclamation, ensuring efficient database management.
- Enhanced logging for space reclamation operations to provide detailed insights into the process.
- Added tests to validate the functionality of periodic cleanup, manual clear operations, and the behavior of shared database access.