### PR TITLE
fix(matcher): preserve negation across runtime controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ plugins:
 | 规则数据 | 域名与 IP 集、GeoIP、GeoSite、AdGuard 规则、动态域名学习 |
 | 系统联动 | Linux `ipset` / `nftset`、RouterOS address-list / static route、HTTP webhook、外部脚本 |
 | 可观测性 | 查询审计与执行路径、实时日志、Prometheus 指标、上游探测、健康检查 |
-| 运行时管理 | 配置校验与热重载、matcher 强制命中/不命中、provider 定向重载、缓存与升级管理 |
+| 运行时管理 | 配置校验与热重载、matcher 基础结果固定、provider 定向重载、缓存与升级管理 |
 | 部署能力 | 多平台构建、Debian 包、OpenWrt LuCI 插件、内置 WebUI 与管理 API、服务化安装 |
 
 完整的内置组件和配置字段见[插件参考](https://oxidns.org/plugin-reference/overview)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -90,7 +90,7 @@ See [Configuration](https://oxidns.org/en/configuration) and [Common Scenarios](
 | Rule data | Domain and IP sets, GeoIP, GeoSite, AdGuard rules, dynamic domain learning |
 | System integrations | Linux `ipset` / `nftset`, RouterOS address lists / static routes, HTTP webhooks, external scripts |
 | Observability | Query auditing and execution paths, real-time logs, Prometheus metrics, upstream probes, health checks |
-| Runtime management | Config validation and hot reload, forced matcher hits/misses, targeted provider reloads, cache and upgrade management |
+| Runtime management | Config validation and hot reload, fixed matcher base results, targeted provider reloads, cache and upgrade management |
 | Deployment | Multi-platform builds, Debian packages, OpenWrt LuCI app, built-in WebUI and management API, service installation |
 
 See the [Plugin Reference](https://oxidns.org/en/plugin-reference/overview) for the complete list of built-in components and configuration fields.

--- a/ai/plugin-dev.md
+++ b/ai/plugin-dev.md
@@ -43,7 +43,7 @@ Fall back to `register_plugin_factory!("type", expr)` only when:
 - Reuse existing abstractions (`DnsContext`, `Executor`, `Matcher`, `Provider`, `RequestHandle`, upstream pools, plugin registry) before introducing parallel frameworks.
 - Keep platform-specific code clearly guarded — especially Linux-only netlink, `ipset`, and `nftset` paths.
 - Management HTTP API integration must compile cleanly without the `api` feature. Gate the module with `#[cfg(feature = "api")]` or keep feature-specific implementations behind internal `cfg` branches when a no-op facade is required.
-- Resolve configured matcher dependencies with `PluginInitContext::matcher_ref(field, tag, reverse)` and evaluate the returned `MatcherRef`. Do not extract an `Arc<dyn Matcher>` and apply `!` outside the reference: runtime `force_hit` / `force_miss` modes override the final expression result after negation.
+- Resolve configured matcher dependencies with `PluginInitContext::matcher_ref(field, tag, reverse)` and evaluate the returned `MatcherRef`. Do not extract an `Arc<dyn Matcher>` and apply `!` outside the reference: runtime `always_true` / `always_false` modes fix the matcher base result before each reference applies its own negation.
 
 ### Package boundaries
 

--- a/ai/webui.md
+++ b/ai/webui.md
@@ -73,7 +73,7 @@ Paths in this guide are relative to `webui/` unless stated otherwise.
 - Keep typography compact: page headings around `text-lg`, operational labels at `text-sm`/`text-xs`, plugin tags and config keys in mono where useful. Do not use oversized hero typography inside the console.
 - Ensure responsive behavior for desktop and narrow screens with stable grids (`sm`, `lg`, `xl`) and fixed-width side panels only when there is enough viewport room. Avoid layouts where labels, buttons, or badges can overlap.
 - Use semantic status color sparingly: primary for active/healthy emphasis, destructive for dangerous actions, yellow/amber only for unsaved or warning states, muted foreground for secondary metadata.
-- Use the shared `warning` color token for `force_miss`, and the `destructive` token for the higher-risk `force_hit` mode. Represent matcher outcomes directly with circled X/check icons; use a neutral controls icon for `normal`. Both forced modes require confirmation, while restoring `normal` does not.
+- Use the shared `warning` color token for `always_false`, and the `destructive` token for the higher-risk `always_true` mode. Represent fixed Boolean values with off/on toggle icons; use a neutral controls icon for `normal`. Both fixed modes require confirmation, while restoring `normal` does not. Confirmation copy must state how positive and negated references behave.
 - Do not add gradient blobs, decorative illustrations, or broad one-color themes. The interface should feel like a precise control surface for OxiDNS.
 
 ## Testing & Documentation

--- a/docs/docs/api.mdx
+++ b/docs/docs/api.mdx
@@ -557,14 +557,14 @@ POST /api/plugins/<matcher_tag>/mode
 设置模式时提交 JSON 请求体：
 
 ```json
-{ "mode": "force_miss" }
+{ "mode": "always_false" }
 ```
 
-`mode` 支持 `normal`、`force_miss` 和 `force_hit`，重复设置同一模式是幂等操作。两个强制模式都会跳过内部 matcher，并覆盖直接引用的最终表达式结果：`force_miss` 使 `$match_cn` 与 `!$match_cn` 都不命中，`force_hit` 使两者都命中。缺少或不支持的模式返回 `400 invalid_matcher_runtime_mode`。
+`mode` 支持 `normal`、`always_false` 和 `always_true`，重复设置同一模式是幂等操作。两个固定模式都会跳过内部 matcher，并固定 matcher 的基础布尔值；每个引用随后仍独立应用取反。因此 `always_false` 下 `$match_cn` 不命中而 `!$match_cn` 命中，`always_true` 下结果相反。缺少或不支持的模式返回 `400 invalid_matcher_runtime_mode`。
 
 模式只属于当前 runtime，不写入 YAML；应用级 reload 或进程重启后恢复为 `normal`。`sequence` 和 `any_match` 内的 quick-setup matcher 使用内部 `qs.match...` tag，不注册控制接口。如需运行时控制，应先将其提取为 `plugins:` 中的独立 matcher 并通过 `$tag` 引用。
 
-WebUI 对 `force_miss` 与 `force_hit` 都要求二次确认；恢复 `normal` 不需要确认。旧的 `/enable`、`/disable` 接口和 `enabled` 响应字段已经移除，API 客户端必须迁移到 `/mode`。
+WebUI 对 `always_false` 与 `always_true` 都要求二次确认；恢复 `normal` 不需要确认。旧的 `/enable`、`/disable` 接口和 `enabled` 响应字段已经移除，API 客户端必须迁移到 `/mode`。
 
 ### provider
 

--- a/docs/docs/plugin-reference/matcher.mdx
+++ b/docs/docs/plugin-reference/matcher.mdx
@@ -14,12 +14,12 @@ import Admonition from "@theme/Admonition";
 | 模式 | `$matcher` | `!$matcher` |
 | --- | --- | --- |
 | `normal` | 使用 matcher 原始结果 | 使用原始结果的取反 |
-| `force_miss` | 不命中 | 不命中 |
-| `force_hit` | 命中 | 命中 |
+| `always_false` | 不命中 | 命中 |
+| `always_true` | 命中 | 不命中 |
 
-`force_miss` 和 `force_hit` 都覆盖直接引用的最终表达式结果，不再执行 matcher 内部逻辑，也不再应用外层取反。WebUI 对两个强制操作都要求二次确认，恢复 `normal` 不需要确认。
+`always_false` 和 `always_true` 会跳过 matcher 内部逻辑并固定其基础布尔值，但每个引用仍独立应用外层取反。WebUI 对两个固定操作都要求二次确认，恢复 `normal` 不需要确认。
 
-强制模式只作用于该 tag 的直接引用。例如把 `any_match` 的一个子 matcher 设为 `force_miss`，只会让该子项贡献 `false`，其它子项仍会正常参与组合；如需控制整个组合，应切换 `any_match` 自身的运行时模式。
+运行时模式由 matcher tag 共享，引用语义则由引用位置决定。例如同一 tag 同时以 `$matcher` 与 `!$matcher` 出现在一个或多个 sequence 中，两者共享同一个固定基础值，但最终结果始终互为取反。`any_match` 的子引用也遵循同一规则；如需控制整个组合，应切换 `any_match` 自身的运行时模式。
 
 该状态不会写入配置，全量 reload 或进程重启后恢复 `normal`。quick-setup matcher 没有稳定的公开 tag，因此不提供运行时模式；需要控制时应先把表达式提取为独立 matcher。接口详情见 [管理 API](../api.mdx#matcher)。
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/api.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/api.mdx
@@ -559,14 +559,14 @@ Both endpoints return the same status shape:
 Set the mode with a JSON request body:
 
 ```json
-{ "mode": "force_miss" }
+{ "mode": "always_false" }
 ```
 
-Supported values are `normal`, `force_miss`, and `force_hit`; setting the current mode again is idempotent. Both forced modes skip the internal matcher and override the final result of a direct reference: `force_miss` makes both `$match_cn` and `!$match_cn` miss, while `force_hit` makes both hit. A missing or unsupported mode returns `400 invalid_matcher_runtime_mode`.
+Supported values are `normal`, `always_false`, and `always_true`; setting the current mode again is idempotent. Both fixed modes skip the internal matcher and fix its base Boolean value, after which each reference still applies its own negation. With `always_false`, `$match_cn` misses and `!$match_cn` matches; `always_true` produces the opposite results. A missing or unsupported mode returns `400 invalid_matcher_runtime_mode`.
 
 The mode belongs only to the current runtime and is not written to YAML. An application reload or process restart restores `normal`. Quick-setup matchers inside `sequence` or `any_match` use internal `qs.match...` tags and do not register these endpoints. Extract a quick-setup expression into a standalone matcher under `plugins:` and reference it with `$tag` when runtime control is required.
 
-The WebUI requires confirmation for both `force_miss` and `force_hit`; restoring `normal` does not require confirmation. The old `/enable` and `/disable` endpoints and the `enabled` response field have been removed, so API clients must migrate to `/mode`.
+The WebUI requires confirmation for both `always_false` and `always_true`; restoring `normal` does not require confirmation. The old `/enable` and `/disable` endpoints and the `enabled` response field have been removed, so API clients must migrate to `/mode`.
 
 ### provider
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/matcher.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/matcher.mdx
@@ -14,12 +14,12 @@ Matchers declared in `plugins:` with stable tags can be inspected and switched a
 | Mode | `$matcher` | `!$matcher` |
 | --- | --- | --- |
 | `normal` | Use the matcher result | Negate the matcher result |
-| `force_miss` | Miss | Miss |
-| `force_hit` | Hit | Hit |
+| `always_false` | Miss | Match |
+| `always_true` | Match | Miss |
 
-Both forced modes override the final result of a direct reference, skip the internal predicate, and bypass outer negation. The WebUI requires confirmation for both forced actions; restoring `normal` does not require confirmation.
+Both fixed modes skip the internal predicate and fix its base Boolean value, but every reference still applies its own outer negation. The WebUI requires confirmation for both fixed actions; restoring `normal` does not require confirmation.
 
-A forced mode applies only to direct references to that tag. For example, forcing one child of `any_match` to miss makes only that child contribute `false`; other children still participate normally. Control the `any_match` tag itself when the entire composition must be overridden.
+The runtime mode is shared by matcher tag, while reference semantics remain local to each reference. If the same tag appears as `$matcher` and `!$matcher` in one or more sequences, both references share the fixed base value but their final results remain opposites. Child references in `any_match` follow the same rule; control the `any_match` tag itself when the entire composition must be fixed.
 
 This state is not written to the configuration, and a full reload or process restart restores `normal`. Quick-setup matchers do not have stable public tags and therefore do not expose runtime modes; extract the expression into a standalone matcher when control is required. See the [Management API](../api.mdx#matcher) for endpoint details.
 

--- a/src/api/runtime_control.rs
+++ b/src/api/runtime_control.rs
@@ -78,7 +78,7 @@ impl ApiHandler for MatcherModeHandler {
                     StatusCode::BAD_REQUEST,
                     "invalid_matcher_runtime_mode",
                     format!(
-                        "request body must contain mode normal, force_miss, or force_hit: {err}"
+                        "request body must contain mode normal, always_false, or always_true: {err}"
                     ),
                 );
             }

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -1031,13 +1031,17 @@ pub(super) fn load_plugin_stats(
                 SUM(CASE
                     WHEN s.kind = 'matcher'
                      AND s.outcome IN (
-                         'matched', 'not_matched', 'force_hit', 'force_miss'
+                         'matched', 'not_matched',
+                         'always_true_matched', 'always_true_not_matched',
+                         'always_false_matched', 'always_false_not_matched'
                      ) THEN 1
                     ELSE 0
                 END) AS checked,
                 SUM(CASE
                     WHEN s.kind = 'matcher'
-                     AND s.outcome IN ('matched', 'force_hit') THEN 1
+                     AND s.outcome IN (
+                         'matched', 'always_true_matched', 'always_false_matched'
+                     ) THEN 1
                     ELSE 0
                 END) AS matched,
                 SUM(CASE
@@ -1653,7 +1657,9 @@ fn record_filter_clauses(
                 SELECT s.record_id
                 FROM {steps} s
                 WHERE s.kind = 'matcher'
-                  AND s.outcome IN ('matched', 'force_hit')
+                  AND s.outcome IN (
+                      'matched', 'always_true_matched', 'always_false_matched'
+                  )
                   AND s.tag = ?
             )",
             steps = tables.steps,

--- a/src/plugin/executor/query_recorder/tests.rs
+++ b/src/plugin/executor/query_recorder/tests.rs
@@ -1135,7 +1135,7 @@ async fn test_query_recorder_matcher_stats_use_record_filters() {
 }
 
 #[tokio::test]
-async fn test_query_recorder_treats_forced_matcher_outcomes_as_effective_results() {
+async fn test_query_recorder_tracks_fixed_values_and_effective_match_results() {
     let temp = NamedTempFile::new().unwrap();
     let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
     let mut plugin = QueryRecorder::new("rec".to_string(), config);
@@ -1150,7 +1150,7 @@ async fn test_query_recorder_treats_forced_matcher_outcomes_as_effective_results
         Ipv4Addr::new(192, 0, 2, 1),
         Some(Rcode::NoError),
         None,
-        &[("controlled", "force_hit")],
+        &[("controlled", "always_true_matched")],
     ));
     backend.enqueue(pending_record(
         2_000,
@@ -1160,7 +1160,27 @@ async fn test_query_recorder_treats_forced_matcher_outcomes_as_effective_results
         Ipv4Addr::new(192, 0, 2, 2),
         Some(Rcode::NoError),
         None,
-        &[("controlled", "force_miss")],
+        &[("controlled", "always_true_not_matched")],
+    ));
+    backend.enqueue(pending_record(
+        3_000,
+        3,
+        "false-negated.example.com.",
+        RecordType::A,
+        Ipv4Addr::new(192, 0, 2, 3),
+        Some(Rcode::NoError),
+        None,
+        &[("controlled", "always_false_matched")],
+    ));
+    backend.enqueue(pending_record(
+        4_000,
+        4,
+        "false-positive.example.com.",
+        RecordType::A,
+        Ipv4Addr::new(192, 0, 2, 4),
+        Some(Rcode::NoError),
+        None,
+        &[("controlled", "always_false_not_matched")],
     ));
     flush_backend(&backend).await;
 
@@ -1172,7 +1192,7 @@ async fn test_query_recorder_treats_forced_matcher_outcomes_as_effective_results
                 ..QueryRecordFilter::default()
             }),
         ),
-        vec![1]
+        vec![3, 1]
     );
 
     let (_, stats) = load_plugin_stats(
@@ -1189,8 +1209,8 @@ async fn test_query_recorder_treats_forced_matcher_outcomes_as_effective_results
         .iter()
         .find(|row| row.tag.as_deref() == Some("controlled"))
         .unwrap();
-    assert_eq!(controlled.checked, 2);
-    assert_eq!(controlled.matched, 1);
+    assert_eq!(controlled.checked, 4);
+    assert_eq!(controlled.matched, 2);
 
     plugin.destroy().await.unwrap();
 }

--- a/src/plugin/executor/sequence/chain.rs
+++ b/src/plugin/executor/sequence/chain.rs
@@ -877,41 +877,91 @@ mod tests {
 
     #[cfg(feature = "_sequence-step-recording")]
     #[tokio::test]
-    async fn test_sequence_records_forced_matcher_outcomes() {
+    async fn test_shared_runtime_mode_preserves_positive_and_negated_references() {
         use crate::plugin::matcher::{MatcherRuntimeControl, MatcherRuntimeMode};
 
         let control = Arc::new(MatcherRuntimeControl::new());
-        let matcher =
-            MatcherRef::with_runtime_control(Arc::new(AlwaysMatcher), true, control.clone());
-        let program = Arc::new(ChainProgram::new(
-            "test_sequence".to_string(),
+        let matcher = Arc::new(AlwaysMatcher);
+        let positive_program = Arc::new(ChainProgram::new(
+            "positive_sequence".to_string(),
             vec![Instruction::new(
                 0,
-                vec![matcher],
+                vec![MatcherRef::with_runtime_control(
+                    matcher.clone(),
+                    false,
+                    control.clone(),
+                )],
+                InstructionOp::Builtin(BuiltinOp::Accept),
+            )],
+        ));
+        let negated_program = Arc::new(ChainProgram::new(
+            "negated_sequence".to_string(),
+            vec![Instruction::new(
+                0,
+                vec![MatcherRef::with_runtime_control(
+                    matcher,
+                    true,
+                    control.clone(),
+                )],
                 InstructionOp::Builtin(BuiltinOp::Accept),
             )],
         ));
 
-        control.set_mode(MatcherRuntimeMode::ForceMiss);
-        let mut miss_context = make_context();
-        miss_context.enable_execution_path();
+        control.set_mode(MatcherRuntimeMode::AlwaysFalse);
+        let mut positive_false_context = make_context();
+        positive_false_context.enable_execution_path();
         assert_eq!(
-            program.run(&mut miss_context).await.unwrap(),
+            positive_program
+                .run(&mut positive_false_context)
+                .await
+                .unwrap(),
             ExecStep::Next
         );
-        assert_eq!(miss_context.execution_path_events().len(), 1);
         assert_eq!(
-            miss_context.execution_path_events()[0].outcome,
-            "force_miss"
+            positive_false_context.execution_path_events()[0].outcome,
+            "always_false_not_matched"
+        );
+        let mut negated_false_context = make_context();
+        negated_false_context.enable_execution_path();
+        assert_eq!(
+            negated_program
+                .run(&mut negated_false_context)
+                .await
+                .unwrap(),
+            ExecStep::Stop
+        );
+        assert_eq!(
+            negated_false_context.execution_path_events()[0].outcome,
+            "always_false_matched"
         );
 
-        control.set_mode(MatcherRuntimeMode::ForceHit);
-        let mut hit_context = make_context();
-        hit_context.enable_execution_path();
-        assert_eq!(program.run(&mut hit_context).await.unwrap(), ExecStep::Stop);
-        assert_eq!(hit_context.execution_path_events().len(), 2);
-        assert_eq!(hit_context.execution_path_events()[0].outcome, "force_hit");
-        assert_eq!(hit_context.execution_path_events()[1].outcome, "stop");
+        control.set_mode(MatcherRuntimeMode::AlwaysTrue);
+        let mut positive_true_context = make_context();
+        positive_true_context.enable_execution_path();
+        assert_eq!(
+            positive_program
+                .run(&mut positive_true_context)
+                .await
+                .unwrap(),
+            ExecStep::Stop
+        );
+        assert_eq!(
+            positive_true_context.execution_path_events()[0].outcome,
+            "always_true_matched"
+        );
+        let mut negated_true_context = make_context();
+        negated_true_context.enable_execution_path();
+        assert_eq!(
+            negated_program
+                .run(&mut negated_true_context)
+                .await
+                .unwrap(),
+            ExecStep::Next
+        );
+        assert_eq!(
+            negated_true_context.execution_path_events()[0].outcome,
+            "always_true_not_matched"
+        );
     }
 
     #[cfg(not(feature = "_sequence-step-recording"))]

--- a/src/plugin/matcher/control.rs
+++ b/src/plugin/matcher/control.rs
@@ -9,7 +9,8 @@ use std::sync::atomic::{AtomicU8, Ordering};
 #[cfg(any(feature = "api", test))]
 use serde::{Deserialize, Serialize};
 
-/// Operational override applied after matcher-expression negation.
+/// Operational override applied to the matcher result before expression
+/// negation.
 #[cfg(any(feature = "api", test))]
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, Eq, PartialEq)]
 #[repr(u8)]
@@ -17,8 +18,8 @@ use serde::{Deserialize, Serialize};
 pub(crate) enum MatcherRuntimeMode {
     #[default]
     Normal = 0,
-    ForceMiss = 1,
-    ForceHit = 2,
+    AlwaysFalse = 1,
+    AlwaysTrue = 2,
 }
 
 #[cfg(any(feature = "api", test))]
@@ -26,8 +27,8 @@ impl MatcherRuntimeMode {
     #[inline]
     fn from_raw(raw: u8) -> Self {
         match raw {
-            value if value == Self::ForceMiss as u8 => Self::ForceMiss,
-            value if value == Self::ForceHit as u8 => Self::ForceHit,
+            value if value == Self::AlwaysFalse as u8 => Self::AlwaysFalse,
+            value if value == Self::AlwaysTrue as u8 => Self::AlwaysTrue,
             _ => Self::Normal,
         }
     }
@@ -100,7 +101,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_modes_override_final_positive_and_negated_results() {
+    fn runtime_modes_fix_the_base_result_before_reference_negation() {
         let calls = Arc::new(AtomicUsize::new(0));
         let matcher: Arc<dyn Matcher> = Arc::new(CountingMatcher {
             calls: calls.clone(),
@@ -118,17 +119,26 @@ mod tests {
         );
         assert_eq!(calls.load(Ordering::Relaxed), 2);
 
-        control.set_mode(MatcherRuntimeMode::ForceMiss);
-        assert_eq!(normal.evaluate(&mut context), MatcherEvaluation::ForceMiss);
+        control.set_mode(MatcherRuntimeMode::AlwaysFalse);
+        assert_eq!(
+            normal.evaluate(&mut context),
+            MatcherEvaluation::AlwaysFalse { matched: false }
+        );
         assert_eq!(
             reversed.evaluate(&mut context),
-            MatcherEvaluation::ForceMiss
+            MatcherEvaluation::AlwaysFalse { matched: true }
         );
         assert_eq!(calls.load(Ordering::Relaxed), 2);
 
-        control.set_mode(MatcherRuntimeMode::ForceHit);
-        assert_eq!(normal.evaluate(&mut context), MatcherEvaluation::ForceHit);
-        assert_eq!(reversed.evaluate(&mut context), MatcherEvaluation::ForceHit);
+        control.set_mode(MatcherRuntimeMode::AlwaysTrue);
+        assert_eq!(
+            normal.evaluate(&mut context),
+            MatcherEvaluation::AlwaysTrue { matched: true }
+        );
+        assert_eq!(
+            reversed.evaluate(&mut context),
+            MatcherEvaluation::AlwaysTrue { matched: false }
+        );
         assert_eq!(calls.load(Ordering::Relaxed), 2);
 
         control.set_mode(MatcherRuntimeMode::Normal);

--- a/src/plugin/matcher/mod.rs
+++ b/src/plugin/matcher/mod.rs
@@ -71,9 +71,13 @@ pub(crate) enum MatcherEvaluation {
     Matched,
     NotMatched,
     #[cfg(any(feature = "api", test))]
-    ForceHit,
+    AlwaysTrue {
+        matched: bool,
+    },
     #[cfg(any(feature = "api", test))]
-    ForceMiss,
+    AlwaysFalse {
+        matched: bool,
+    },
 }
 
 impl MatcherEvaluation {
@@ -83,9 +87,9 @@ impl MatcherEvaluation {
             Self::Matched => true,
             Self::NotMatched => false,
             #[cfg(any(feature = "api", test))]
-            Self::ForceHit => true,
+            Self::AlwaysTrue { matched } => matched,
             #[cfg(any(feature = "api", test))]
-            Self::ForceMiss => false,
+            Self::AlwaysFalse { matched } => matched,
         }
     }
 
@@ -96,9 +100,13 @@ impl MatcherEvaluation {
             Self::Matched => "matched",
             Self::NotMatched => "not_matched",
             #[cfg(any(feature = "api", test))]
-            Self::ForceHit => "force_hit",
+            Self::AlwaysTrue { matched: true } => "always_true_matched",
             #[cfg(any(feature = "api", test))]
-            Self::ForceMiss => "force_miss",
+            Self::AlwaysTrue { matched: false } => "always_true_not_matched",
+            #[cfg(any(feature = "api", test))]
+            Self::AlwaysFalse { matched: true } => "always_false_matched",
+            #[cfg(any(feature = "api", test))]
+            Self::AlwaysFalse { matched: false } => "always_false_not_matched",
         }
     }
 }
@@ -138,8 +146,16 @@ impl MatcherRef {
         #[cfg(any(feature = "api", test))]
         if let Some(control) = &self.runtime_control {
             match control.mode() {
-                MatcherRuntimeMode::ForceMiss => return MatcherEvaluation::ForceMiss,
-                MatcherRuntimeMode::ForceHit => return MatcherEvaluation::ForceHit,
+                MatcherRuntimeMode::AlwaysFalse => {
+                    return MatcherEvaluation::AlwaysFalse {
+                        matched: self.reverse,
+                    };
+                }
+                MatcherRuntimeMode::AlwaysTrue => {
+                    return MatcherEvaluation::AlwaysTrue {
+                        matched: !self.reverse,
+                    };
+                }
                 MatcherRuntimeMode::Normal => {}
             }
         }

--- a/src/plugin/provider/mod.rs
+++ b/src/plugin/provider/mod.rs
@@ -217,7 +217,20 @@ mod tests {
                 args: Some(serde_yaml_ng::from_str("- \"$reloadable\"").unwrap()),
             },
             PluginConfig {
-                tag: "controlled_sequence".to_string(),
+                tag: "positive_sequence".to_string(),
+                plugin_type: "sequence".to_string(),
+                args: Some(
+                    serde_yaml_ng::from_str(
+                        r#"
+- matches: "$match_qname"
+  exec: reject 2
+"#,
+                    )
+                    .unwrap(),
+                ),
+            },
+            PluginConfig {
+                tag: "negated_sequence".to_string(),
                 plugin_type: "sequence".to_string(),
                 args: Some(
                     serde_yaml_ng::from_str(
@@ -295,22 +308,40 @@ mod tests {
         assert_eq!(payload["matcher"], "match_qname");
         assert_eq!(payload["mode"], "normal");
         assert!(payload.get("enabled").is_none());
-        let sequence = registry
-            .get_plugin("controlled_sequence")
-            .expect("sequence should be initialized")
+        let positive_sequence = registry
+            .get_plugin("positive_sequence")
+            .expect("positive sequence should be initialized")
             .to_executor();
-        let public_matcher_ref = PluginResolver::matcher_ref(
+        let negated_sequence = registry
+            .get_plugin("negated_sequence")
+            .expect("negated sequence should be initialized")
+            .to_executor();
+        let public_positive_ref = PluginResolver::matcher_ref(
             registry.as_ref(),
-            "controlled_sequence",
+            "positive_sequence",
+            "args[0].matches[0]",
+            "match_qname",
+            false,
+        )?;
+        let public_negated_ref = PluginResolver::matcher_ref(
+            registry.as_ref(),
+            "negated_sequence",
             "args[0].matches[0]",
             "match_qname",
             true,
         )?;
-        let mut normal_context = test_context();
-        sequence.execute(&mut normal_context).await?;
-        assert!(normal_context.response().is_some());
-        let mut public_normal_context = test_context();
-        assert!(public_matcher_ref.is_match(&mut public_normal_context));
+        let mut positive_normal_context = test_context();
+        positive_sequence
+            .execute(&mut positive_normal_context)
+            .await?;
+        assert!(positive_normal_context.response().is_none());
+        let mut negated_normal_context = test_context();
+        negated_sequence
+            .execute(&mut negated_normal_context)
+            .await?;
+        assert!(negated_normal_context.response().is_some());
+        assert!(!public_positive_ref.is_match(&mut test_context()));
+        assert!(public_negated_ref.is_match(&mut test_context()));
 
         let uri: Uri = format!("http://{listen}/api/plugins/match_qname/mode")
             .parse()
@@ -322,7 +353,7 @@ mod tests {
                     .uri(uri)
                     .header(http::header::CONTENT_TYPE, "application/json")
                     .body(Full::new(bytes::Bytes::from_static(
-                        br#"{"mode":"force_miss"}"#,
+                        br#"{"mode":"always_false"}"#,
                     )))
                     .expect("request should build"),
             )
@@ -338,12 +369,17 @@ mod tests {
                 .to_bytes(),
         )
         .expect("response should be valid json");
-        assert_eq!(payload["mode"], "force_miss");
-        let mut force_miss_context = test_context();
-        sequence.execute(&mut force_miss_context).await?;
-        assert!(force_miss_context.response().is_none());
-        let mut public_force_miss_context = test_context();
-        assert!(!public_matcher_ref.is_match(&mut public_force_miss_context));
+        assert_eq!(payload["mode"], "always_false");
+        let mut positive_false_context = test_context();
+        positive_sequence
+            .execute(&mut positive_false_context)
+            .await?;
+        assert!(positive_false_context.response().is_none());
+        let mut negated_false_context = test_context();
+        negated_sequence.execute(&mut negated_false_context).await?;
+        assert!(negated_false_context.response().is_some());
+        assert!(!public_positive_ref.is_match(&mut test_context()));
+        assert!(public_negated_ref.is_match(&mut test_context()));
 
         let uri: Uri = format!("http://{listen}/api/plugins/match_qname/mode")
             .parse()
@@ -355,7 +391,7 @@ mod tests {
                     .uri(uri)
                     .header(http::header::CONTENT_TYPE, "application/json")
                     .body(Full::new(bytes::Bytes::from_static(
-                        br#"{"mode":"force_hit"}"#,
+                        br#"{"mode":"always_true"}"#,
                     )))
                     .expect("request should build"),
             )
@@ -371,12 +407,17 @@ mod tests {
                 .to_bytes(),
         )
         .expect("response should be valid json");
-        assert_eq!(payload["mode"], "force_hit");
-        let mut force_hit_context = test_context();
-        sequence.execute(&mut force_hit_context).await?;
-        assert!(force_hit_context.response().is_some());
-        let mut public_force_hit_context = test_context();
-        assert!(public_matcher_ref.is_match(&mut public_force_hit_context));
+        assert_eq!(payload["mode"], "always_true");
+        let mut positive_true_context = test_context();
+        positive_sequence
+            .execute(&mut positive_true_context)
+            .await?;
+        assert!(positive_true_context.response().is_some());
+        let mut negated_true_context = test_context();
+        negated_sequence.execute(&mut negated_true_context).await?;
+        assert!(negated_true_context.response().is_none());
+        assert!(public_positive_ref.is_match(&mut test_context()));
+        assert!(!public_negated_ref.is_match(&mut test_context()));
 
         let uri: Uri = format!("http://{listen}/api/plugins/match_qname/mode")
             .parse()

--- a/src/plugin/registry/context.rs
+++ b/src/plugin/registry/context.rs
@@ -103,9 +103,9 @@ impl<'a> PluginInitContext<'a> {
 
     /// Resolve a configured matcher expression with its runtime control.
     ///
-    /// `reverse` represents the expression-level `!` modifier. Runtime force
-    /// modes are applied after this modifier, so consumers must keep matcher
-    /// evaluation inside the returned [`MatcherRef`].
+    /// `reverse` represents the expression-level `!` modifier. Runtime modes
+    /// determine the matcher base result first, then this modifier is applied,
+    /// so consumers must keep evaluation inside the returned [`MatcherRef`].
     pub fn matcher_ref(&self, field: &str, target_tag: &str, reverse: bool) -> Result<MatcherRef> {
         self.registry
             .get_matcher_ref_dependency(&self.tag, field, target_tag, reverse)

--- a/src/plugin/registry/mod.rs
+++ b/src/plugin/registry/mod.rs
@@ -527,7 +527,7 @@ impl PluginRegistry {
     }
 
     /// Resolve a matcher dependency together with expression-level negation
-    /// and the runtime force-mode control shared by its configured tag.
+    /// and the runtime base-result control shared by its configured tag.
     pub fn get_matcher_ref_dependency(
         &self,
         source_tag: &str,

--- a/webui/components/plugins/kinds/query-recorder.tsx
+++ b/webui/components/plugins/kinds/query-recorder.tsx
@@ -2510,7 +2510,9 @@ function recordMatchesFilters(
       !steps?.some(
         (step) =>
           step.kind === "matcher" &&
-          (step.outcome === "matched" || step.outcome === "force_hit") &&
+          (step.outcome === "matched" ||
+            step.outcome === "always_true_matched" ||
+            step.outcome === "always_false_matched") &&
           step.tag === filters.matcherTag,
       )
     ) {

--- a/webui/components/plugins/matcher-runtime-control.tsx
+++ b/webui/components/plugins/matcher-runtime-control.tsx
@@ -2,10 +2,10 @@
 
 import { useState, type MouseEvent } from "react";
 import {
-  CheckCircle2Icon,
   RotateCcwIcon,
   SlidersHorizontalIcon,
-  XCircleIcon,
+  ToggleLeftIcon,
+  ToggleRightIcon,
 } from "lucide-react";
 
 import {
@@ -47,7 +47,7 @@ import { WEBUI } from "@/lib/i18n";
 import { useI18n } from "@/lib/i18n/provider";
 import {
   planMatcherModeChange,
-  type ForcedMatcherRuntimeMode,
+  type FixedMatcherRuntimeMode,
   type MatcherRuntimeMode,
 } from "@/lib/matcher-control";
 import { useAppStore } from "@/lib/store";
@@ -65,7 +65,7 @@ export function MatcherRuntimeControl({
 }: MatcherRuntimeControlProps) {
   const { t } = useI18n();
   const [confirmMode, setConfirmMode] =
-    useState<ForcedMatcherRuntimeMode | null>(null);
+    useState<FixedMatcherRuntimeMode | null>(null);
   const control = useAppStore((state) => state.matcherControls[plugin.name]);
   const setMatcherMode = useAppStore((state) => state.setMatcherMode);
 
@@ -74,35 +74,35 @@ export function MatcherRuntimeControl({
   const ready = control?.availability === "ready" && control.mode !== null;
   const pending = Boolean(control?.pending);
   const currentMode = ready ? control.mode : null;
-  const forcedMiss = currentMode === "force_miss";
-  const forcedHit = currentMode === "force_hit";
-  const forced = forcedMiss || forcedHit;
+  const alwaysFalse = currentMode === "always_false";
+  const alwaysTrue = currentMode === "always_true";
+  const fixed = alwaysFalse || alwaysTrue;
   const loading = control?.availability === "loading";
   const unavailable = !ready && !loading;
   const positiveReference = `$${plugin.name}`;
   const negativeReference = `!$${plugin.name}`;
 
   const statusLabel = ready
-    ? forcedMiss
-      ? t(WEBUI.plugins.matcherForceMiss)
-      : forcedHit
-        ? t(WEBUI.plugins.matcherForceHit)
+    ? alwaysFalse
+      ? t(WEBUI.plugins.matcherAlwaysFalse)
+      : alwaysTrue
+        ? t(WEBUI.plugins.matcherAlwaysTrue)
         : t(WEBUI.plugins.matcherRuntimeNormal)
     : loading
       ? t(WEBUI.plugins.matcherControlLoading)
       : t(WEBUI.plugins.matcherControlUnavailable);
 
   const statusDescription = ready
-    ? forcedMiss
-      ? t(WEBUI.plugins.matcherForceMissDescription)
-      : forcedHit
-        ? t(WEBUI.plugins.matcherForceHitDescription)
+    ? alwaysFalse
+      ? t(WEBUI.plugins.matcherAlwaysFalseDescription)
+      : alwaysTrue
+        ? t(WEBUI.plugins.matcherAlwaysTrueDescription)
         : t(WEBUI.plugins.matcherRuntimeNormalDescription)
     : loading
       ? t(WEBUI.plugins.matcherControlLoading)
       : t(WEBUI.plugins.matcherControlUnavailable);
 
-  const applyForcedMode = async (event: MouseEvent<HTMLButtonElement>) => {
+  const applyFixedMode = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     if (!confirmMode) return;
     try {
@@ -126,10 +126,10 @@ export function MatcherRuntimeControl({
 
   const modeIcon = loading ? (
     <Spinner data-icon="inline-start" />
-  ) : forcedMiss ? (
-    <XCircleIcon data-icon="inline-start" />
-  ) : forcedHit ? (
-    <CheckCircle2Icon data-icon="inline-start" />
+  ) : alwaysFalse ? (
+    <ToggleLeftIcon data-icon="inline-start" />
+  ) : alwaysTrue ? (
+    <ToggleRightIcon data-icon="inline-start" />
   ) : (
     <SlidersHorizontalIcon data-icon="inline-start" />
   );
@@ -150,25 +150,25 @@ export function MatcherRuntimeControl({
       <DropdownMenuContent align="end" className="min-w-44">
         <DropdownMenuLabel>{statusLabel}</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        {forced ? (
+        {fixed ? (
           <DropdownMenuItem onSelect={() => requestModeChange("normal")}>
             <RotateCcwIcon />
             {t(WEBUI.plugins.matcherRestoreAction)}
           </DropdownMenuItem>
         ) : null}
-        {!forcedMiss ? (
-          <DropdownMenuItem onSelect={() => requestModeChange("force_miss")}>
-            <XCircleIcon />
-            {t(WEBUI.plugins.matcherForceMissAction)}
+        {!alwaysFalse ? (
+          <DropdownMenuItem onSelect={() => requestModeChange("always_false")}>
+            <ToggleLeftIcon />
+            {t(WEBUI.plugins.matcherAlwaysFalseAction)}
           </DropdownMenuItem>
         ) : null}
-        {!forcedHit ? (
+        {!alwaysTrue ? (
           <DropdownMenuItem
             variant="destructive"
-            onSelect={() => requestModeChange("force_hit")}
+            onSelect={() => requestModeChange("always_true")}
           >
-            <CheckCircle2Icon />
-            {t(WEBUI.plugins.matcherForceHitAction)}
+            <ToggleRightIcon />
+            {t(WEBUI.plugins.matcherAlwaysTrueAction)}
           </DropdownMenuItem>
         ) : null}
       </DropdownMenuContent>
@@ -186,39 +186,39 @@ export function MatcherRuntimeControl({
         <AlertDialogHeader>
           <AlertDialogMedia
             className={cn(
-              confirmMode === "force_hit"
+              confirmMode === "always_true"
                 ? "bg-destructive/10 text-destructive"
                 : "bg-warning/15 text-warning-foreground",
             )}
           >
-            {confirmMode === "force_hit" ? (
-              <CheckCircle2Icon />
+            {confirmMode === "always_true" ? (
+              <ToggleRightIcon />
             ) : (
-              <XCircleIcon />
+              <ToggleLeftIcon />
             )}
           </AlertDialogMedia>
           <AlertDialogTitle>
             {t(
-              confirmMode === "force_hit"
-                ? WEBUI.plugins.matcherForceHitConfirmTitle
-                : WEBUI.plugins.matcherForceMissConfirmTitle,
+              confirmMode === "always_true"
+                ? WEBUI.plugins.matcherAlwaysTrueConfirmTitle
+                : WEBUI.plugins.matcherAlwaysFalseConfirmTitle,
               { tag: plugin.name },
             )}
           </AlertDialogTitle>
           <AlertDialogDescription>
             {t(
-              confirmMode === "force_hit"
-                ? WEBUI.plugins.matcherForceHitConfirmDescription
-                : WEBUI.plugins.matcherForceMissConfirmDescription,
+              confirmMode === "always_true"
+                ? WEBUI.plugins.matcherAlwaysTrueConfirmDescription
+                : WEBUI.plugins.matcherAlwaysFalseConfirmDescription,
             )}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <div className="flex flex-col gap-2 text-sm text-muted-foreground">
           <p>
             {t(
-              confirmMode === "force_hit"
-                ? WEBUI.plugins.matcherForceHitImpact
-                : WEBUI.plugins.matcherForceMissImpact,
+              confirmMode === "always_true"
+                ? WEBUI.plugins.matcherAlwaysTrueImpact
+                : WEBUI.plugins.matcherAlwaysFalseImpact,
               {
                 positive: positiveReference,
                 negative: negativeReference,
@@ -237,15 +237,15 @@ export function MatcherRuntimeControl({
             {t(WEBUI.common.cancel)}
           </AlertDialogCancel>
           <AlertDialogAction
-            variant={confirmMode === "force_hit" ? "destructive" : "warning"}
+            variant={confirmMode === "always_true" ? "destructive" : "warning"}
             disabled={pending || confirmMode === null}
-            onClick={applyForcedMode}
+            onClick={applyFixedMode}
           >
             {pending ? <Spinner data-icon="inline-start" /> : null}
             {t(
-              confirmMode === "force_hit"
-                ? WEBUI.plugins.matcherForceHitConfirmAction
-                : WEBUI.plugins.matcherForceMissConfirmAction,
+              confirmMode === "always_true"
+                ? WEBUI.plugins.matcherAlwaysTrueConfirmAction
+                : WEBUI.plugins.matcherAlwaysFalseConfirmAction,
             )}
           </AlertDialogAction>
         </AlertDialogFooter>
@@ -255,7 +255,7 @@ export function MatcherRuntimeControl({
 
   const detailActions = (
     <div className="flex flex-wrap items-center gap-2">
-      {forced ? (
+      {fixed ? (
         <Button
           variant="outline"
           size="sm"
@@ -266,26 +266,26 @@ export function MatcherRuntimeControl({
           {t(WEBUI.plugins.matcherRestoreAction)}
         </Button>
       ) : null}
-      {!forcedMiss ? (
+      {!alwaysFalse ? (
         <Button
           variant="warning"
           size="sm"
           disabled={!ready || pending}
-          onClick={() => requestModeChange("force_miss")}
+          onClick={() => requestModeChange("always_false")}
         >
-          <XCircleIcon />
-          {t(WEBUI.plugins.matcherForceMissAction)}
+          <ToggleLeftIcon />
+          {t(WEBUI.plugins.matcherAlwaysFalseAction)}
         </Button>
       ) : null}
-      {!forcedHit ? (
+      {!alwaysTrue ? (
         <Button
           variant="destructive"
           size="sm"
           disabled={!ready || pending}
-          onClick={() => requestModeChange("force_hit")}
+          onClick={() => requestModeChange("always_true")}
         >
-          <CheckCircle2Icon />
-          {t(WEBUI.plugins.matcherForceHitAction)}
+          <ToggleRightIcon />
+          {t(WEBUI.plugins.matcherAlwaysTrueAction)}
         </Button>
       ) : null}
     </div>
@@ -317,8 +317,8 @@ export function MatcherRuntimeControl({
     <Card
       className={cn(
         "mt-4",
-        forcedMiss && "border-warning/40 bg-warning/5",
-        forcedHit && "border-destructive/40 bg-destructive/5",
+        alwaysFalse && "border-warning/40 bg-warning/5",
+        alwaysTrue && "border-destructive/40 bg-destructive/5",
       )}
     >
       <CardHeader className="flex flex-row items-start justify-between gap-3">
@@ -330,9 +330,9 @@ export function MatcherRuntimeControl({
         </div>
         <Badge
           variant={
-            forcedHit
+            alwaysTrue
               ? "destructive"
-              : forcedMiss
+              : alwaysFalse
                 ? "warning"
                 : ready
                   ? "secondary"
@@ -343,15 +343,15 @@ export function MatcherRuntimeControl({
           {statusLabel}
         </Badge>
       </CardHeader>
-      {forced || control?.error ? (
+      {fixed || control?.error ? (
         <CardContent className="flex flex-col gap-2 text-xs text-muted-foreground">
-          {forced ? (
+          {fixed ? (
             <>
               <p>
                 {t(
-                  forcedHit
-                    ? WEBUI.plugins.matcherForceHitImpact
-                    : WEBUI.plugins.matcherForceMissImpact,
+                  alwaysTrue
+                    ? WEBUI.plugins.matcherAlwaysTrueImpact
+                    : WEBUI.plugins.matcherAlwaysFalseImpact,
                   {
                     positive: positiveReference,
                     negative: negativeReference,

--- a/webui/components/plugins/plugin-card-template.tsx
+++ b/webui/components/plugins/plugin-card-template.tsx
@@ -56,12 +56,12 @@ export function PluginCardTemplate({
     plugin.type,
     plugin.pluginKind,
   );
-  const matcherForceMiss =
+  const matcherAlwaysFalse =
     matcherControl?.availability === "ready" &&
-    matcherControl.mode === "force_miss";
-  const matcherForceHit =
+    matcherControl.mode === "always_false";
+  const matcherAlwaysTrue =
     matcherControl?.availability === "ready" &&
-    matcherControl.mode === "force_hit";
+    matcherControl.mode === "always_true";
   const resolvedIcon =
     icon ??
     (definition
@@ -80,9 +80,9 @@ export function PluginCardTemplate({
       className={cn(
         "group relative flex h-full min-h-[10.75rem] cursor-pointer flex-col gap-0 overflow-hidden py-0 transition-[border-color,box-shadow,transform] duration-200 hover:-translate-y-px hover:border-primary/40 hover:shadow-md",
         plugin.pinned && "border-primary/30",
-        matcherForceMiss &&
+        matcherAlwaysFalse &&
           "border-warning/40 bg-warning/5 hover:border-warning/60",
-        matcherForceHit &&
+        matcherAlwaysTrue &&
           "border-destructive/40 bg-destructive/5 hover:border-destructive/60",
         !supported && "border-dashed opacity-70",
       )}

--- a/webui/components/plugins/query-record-flow.tsx
+++ b/webui/components/plugins/query-record-flow.tsx
@@ -22,8 +22,8 @@ import {
   GitBranch,
   Play,
   RotateCcw,
-  CheckCircle2,
-  XCircle,
+  ToggleLeft,
+  ToggleRight,
   X,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -54,8 +54,10 @@ import { useI18n } from "@/lib/i18n/provider";
 type MatchStatus =
   | "matched"
   | "not_matched"
-  | "force_hit"
-  | "force_miss"
+  | "always_true_matched"
+  | "always_true_not_matched"
+  | "always_false_matched"
+  | "always_false_not_matched"
   | "unchecked";
 type ActionStatus =
   | "not_executed"
@@ -250,10 +252,16 @@ export function QueryRecordFlowCanvas({
           {t(WEBUI.queryRecordFlow.notMatched)}
         </span>
         <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 text-destructive">
-          {t(WEBUI.queryRecordFlow.forceHit)}
+          {t(WEBUI.queryRecordFlow.alwaysTrueMatched)}
+        </span>
+        <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 text-destructive">
+          {t(WEBUI.queryRecordFlow.alwaysTrueNotMatched)}
         </span>
         <span className="rounded-full border border-warning/40 bg-warning/10 px-2 py-0.5 text-warning-foreground">
-          {t(WEBUI.queryRecordFlow.forceMiss)}
+          {t(WEBUI.queryRecordFlow.alwaysFalseMatched)}
+        </span>
+        <span className="rounded-full border border-warning/40 bg-warning/10 px-2 py-0.5 text-warning-foreground">
+          {t(WEBUI.queryRecordFlow.alwaysFalseNotMatched)}
         </span>
         <span className="rounded-full border bg-muted/30 px-2 py-0.5">
           {t(WEBUI.queryRecordFlow.unchecked)}
@@ -586,9 +594,8 @@ function SequenceRuleRow({
     rule.exec,
     runtime,
   );
-  const missed = matchStatuses.some(
-    (status) =>
-      status.status === "not_matched" || status.status === "force_miss",
+  const missed = matchStatuses.some((status) =>
+    isMissedMatchStatus(status.status),
   );
   const ran = actionStatus.status !== "not_executed";
 
@@ -996,8 +1003,10 @@ function getMatchStatus(
   const status: MatchStatus =
     last?.outcome === "matched" ||
     last?.outcome === "not_matched" ||
-    last?.outcome === "force_hit" ||
-    last?.outcome === "force_miss"
+    last?.outcome === "always_true_matched" ||
+    last?.outcome === "always_true_not_matched" ||
+    last?.outcome === "always_false_matched" ||
+    last?.outcome === "always_false_not_matched"
       ? last.outcome
       : "unchecked";
   return { status, events, runtimeTag };
@@ -1168,11 +1177,11 @@ function InvertMark() {
 function matchStatusIcon(status: MatchStatus) {
   if (status === "matched") return <Check className="h-3 w-3 shrink-0" />;
   if (status === "not_matched") return <X className="h-3 w-3 shrink-0" />;
-  if (status === "force_hit") {
-    return <CheckCircle2 className="h-3 w-3 shrink-0" />;
+  if (status.startsWith("always_true_")) {
+    return <ToggleRight className="h-3 w-3 shrink-0" />;
   }
-  if (status === "force_miss") {
-    return <XCircle className="h-3 w-3 shrink-0" />;
+  if (status.startsWith("always_false_")) {
+    return <ToggleLeft className="h-3 w-3 shrink-0" />;
   }
   return <Circle className="h-3 w-3 shrink-0" />;
 }
@@ -1186,8 +1195,18 @@ function actionStatusIcon(status: ActionStatus) {
 function matchStatusLabel(status: MatchStatus, t: TFn) {
   if (status === "matched") return t(WEBUI.queryRecordFlow.matched);
   if (status === "not_matched") return t(WEBUI.queryRecordFlow.notMatched);
-  if (status === "force_hit") return t(WEBUI.queryRecordFlow.forceHit);
-  if (status === "force_miss") return t(WEBUI.queryRecordFlow.forceMiss);
+  if (status === "always_true_matched") {
+    return t(WEBUI.queryRecordFlow.alwaysTrueMatched);
+  }
+  if (status === "always_true_not_matched") {
+    return t(WEBUI.queryRecordFlow.alwaysTrueNotMatched);
+  }
+  if (status === "always_false_matched") {
+    return t(WEBUI.queryRecordFlow.alwaysFalseMatched);
+  }
+  if (status === "always_false_not_matched") {
+    return t(WEBUI.queryRecordFlow.alwaysFalseNotMatched);
+  }
   return t(WEBUI.queryRecordFlow.unchecked);
 }
 
@@ -1215,13 +1234,17 @@ function matchStatusClass(status: MatchStatus) {
   if (status === "not_matched") {
     return "border-rose-500/30 bg-rose-500/10 text-rose-700 hover:border-rose-500/60 dark:text-rose-300";
   }
-  if (status === "force_hit") {
+  if (status.startsWith("always_true_")) {
     return "border-destructive/40 bg-destructive/10 text-destructive hover:border-destructive/70";
   }
-  if (status === "force_miss") {
+  if (status.startsWith("always_false_")) {
     return "border-warning/40 bg-warning/10 text-warning-foreground hover:border-warning/70";
   }
   return "border-border bg-muted/30 text-muted-foreground hover:border-primary/40";
+}
+
+function isMissedMatchStatus(status: MatchStatus) {
+  return status === "not_matched" || status.endsWith("_not_matched");
 }
 
 function actionStatusClass(status: ActionStatus) {

--- a/webui/lib/i18n/keys.ts
+++ b/webui/lib/i18n/keys.ts
@@ -174,25 +174,29 @@ export const WEBUI = {
     matcherRuntimeNormal: "webui.plugins.matcherRuntimeNormal",
     matcherRuntimeNormalDescription:
       "webui.plugins.matcherRuntimeNormalDescription",
-    matcherForceMiss: "webui.plugins.matcherForceMiss",
-    matcherForceMissDescription: "webui.plugins.matcherForceMissDescription",
-    matcherForceMissAction: "webui.plugins.matcherForceMissAction",
-    matcherForceHit: "webui.plugins.matcherForceHit",
-    matcherForceHitDescription: "webui.plugins.matcherForceHitDescription",
-    matcherForceHitAction: "webui.plugins.matcherForceHitAction",
+    matcherAlwaysFalse: "webui.plugins.matcherAlwaysFalse",
+    matcherAlwaysFalseDescription:
+      "webui.plugins.matcherAlwaysFalseDescription",
+    matcherAlwaysFalseAction: "webui.plugins.matcherAlwaysFalseAction",
+    matcherAlwaysTrue: "webui.plugins.matcherAlwaysTrue",
+    matcherAlwaysTrueDescription: "webui.plugins.matcherAlwaysTrueDescription",
+    matcherAlwaysTrueAction: "webui.plugins.matcherAlwaysTrueAction",
     matcherModeActions: "webui.plugins.matcherModeActions",
     matcherRestoreAction: "webui.plugins.matcherRestoreAction",
-    matcherForceMissConfirmTitle: "webui.plugins.matcherForceMissConfirmTitle",
-    matcherForceMissConfirmDescription:
-      "webui.plugins.matcherForceMissConfirmDescription",
-    matcherForceMissImpact: "webui.plugins.matcherForceMissImpact",
-    matcherForceMissConfirmAction:
-      "webui.plugins.matcherForceMissConfirmAction",
-    matcherForceHitConfirmTitle: "webui.plugins.matcherForceHitConfirmTitle",
-    matcherForceHitConfirmDescription:
-      "webui.plugins.matcherForceHitConfirmDescription",
-    matcherForceHitImpact: "webui.plugins.matcherForceHitImpact",
-    matcherForceHitConfirmAction: "webui.plugins.matcherForceHitConfirmAction",
+    matcherAlwaysFalseConfirmTitle:
+      "webui.plugins.matcherAlwaysFalseConfirmTitle",
+    matcherAlwaysFalseConfirmDescription:
+      "webui.plugins.matcherAlwaysFalseConfirmDescription",
+    matcherAlwaysFalseImpact: "webui.plugins.matcherAlwaysFalseImpact",
+    matcherAlwaysFalseConfirmAction:
+      "webui.plugins.matcherAlwaysFalseConfirmAction",
+    matcherAlwaysTrueConfirmTitle:
+      "webui.plugins.matcherAlwaysTrueConfirmTitle",
+    matcherAlwaysTrueConfirmDescription:
+      "webui.plugins.matcherAlwaysTrueConfirmDescription",
+    matcherAlwaysTrueImpact: "webui.plugins.matcherAlwaysTrueImpact",
+    matcherAlwaysTrueConfirmAction:
+      "webui.plugins.matcherAlwaysTrueConfirmAction",
     matcherModeResetHint: "webui.plugins.matcherModeResetHint",
     matcherControlLoading: "webui.plugins.matcherControlLoading",
     matcherControlUnavailable: "webui.plugins.matcherControlUnavailable",
@@ -482,8 +486,10 @@ export const WEBUI = {
     eventCount: "webui.queryRecordFlow.eventCount",
     matched: "webui.queryRecordFlow.matched",
     notMatched: "webui.queryRecordFlow.notMatched",
-    forceHit: "webui.queryRecordFlow.forceHit",
-    forceMiss: "webui.queryRecordFlow.forceMiss",
+    alwaysTrueMatched: "webui.queryRecordFlow.alwaysTrueMatched",
+    alwaysTrueNotMatched: "webui.queryRecordFlow.alwaysTrueNotMatched",
+    alwaysFalseMatched: "webui.queryRecordFlow.alwaysFalseMatched",
+    alwaysFalseNotMatched: "webui.queryRecordFlow.alwaysFalseNotMatched",
     unchecked: "webui.queryRecordFlow.unchecked",
     topologyUnavailable: "webui.queryRecordFlow.topologyUnavailable",
     missingSequenceConfig: "webui.queryRecordFlow.missingSequenceConfig",

--- a/webui/lib/i18n/locales/en-US/webui.ts
+++ b/webui/lib/i18n/locales/en-US/webui.ts
@@ -183,28 +183,28 @@ export const enUSWebui = {
     matcherRuntimeNormal: "Participating normally",
     matcherRuntimeNormalDescription:
       "This matcher is participating in rule evaluation as configured.",
-    matcherForceMiss: "Forced miss",
-    matcherForceMissDescription:
-      "Every direct reference to this matcher currently misses without running its internal predicate.",
-    matcherForceMissAction: "Force miss",
-    matcherForceHit: "Forced hit",
-    matcherForceHitDescription:
-      "Every direct reference to this matcher currently hits without running its internal predicate.",
-    matcherForceHitAction: "Force hit",
+    matcherAlwaysFalse: "Fixed to false",
+    matcherAlwaysFalseDescription:
+      "This matcher's base result is fixed to false; each reference still applies its own negation.",
+    matcherAlwaysFalseAction: "Fix to false",
+    matcherAlwaysTrue: "Fixed to true",
+    matcherAlwaysTrueDescription:
+      "This matcher's base result is fixed to true; each reference still applies its own negation.",
+    matcherAlwaysTrueAction: "Fix to true",
     matcherModeActions: "Matcher runtime mode",
     matcherRestoreAction: "Restore matching",
-    matcherForceMissConfirmTitle: "Force {tag} to miss?",
-    matcherForceMissConfirmDescription:
+    matcherAlwaysFalseConfirmTitle: "Fix {tag}'s base result to false?",
+    matcherAlwaysFalseConfirmDescription:
       "This skips the internal predicate, affects only the current runtime, and does not modify configuration.",
-    matcherForceMissImpact:
-      "Conditions directly referencing {positive} and {negative} will both miss.",
-    matcherForceMissConfirmAction: "Confirm forced miss",
-    matcherForceHitConfirmTitle: "Force {tag} to hit?",
-    matcherForceHitConfirmDescription:
-      "This skips the internal predicate, may activate multiple policy branches, and affects only the current runtime.",
-    matcherForceHitImpact:
-      "Conditions directly referencing {positive} and {negative} will both hit.",
-    matcherForceHitConfirmAction: "Confirm forced hit",
+    matcherAlwaysFalseImpact:
+      "{positive} will miss; {negative} will match after negation.",
+    matcherAlwaysFalseConfirmAction: "Confirm fixed false",
+    matcherAlwaysTrueConfirmTitle: "Fix {tag}'s base result to true?",
+    matcherAlwaysTrueConfirmDescription:
+      "This skips the internal predicate, may activate policy branches that reference it, and affects only the current runtime.",
+    matcherAlwaysTrueImpact:
+      "{positive} will match; {negative} will miss after negation.",
+    matcherAlwaysTrueConfirmAction: "Confirm fixed true",
     matcherModeResetHint:
       "An application reload or process restart restores normal matching.",
     matcherControlLoading: "Loading matcher runtime state",
@@ -434,8 +434,10 @@ export const enUSWebui = {
     eventCount: "{count} events",
     matched: "Matched",
     notMatched: "Not matched",
-    forceHit: "Forced hit",
-    forceMiss: "Forced miss",
+    alwaysTrueMatched: "Fixed true · matched",
+    alwaysTrueNotMatched: "Fixed true · negated miss",
+    alwaysFalseMatched: "Fixed false · negated match",
+    alwaysFalseNotMatched: "Fixed false · missed",
     unchecked: "Unchecked",
     topologyUnavailable:
       "Config topology is unavailable; showing events in recorded order.",

--- a/webui/lib/i18n/locales/zh-CN/webui.ts
+++ b/webui/lib/i18n/locales/zh-CN/webui.ts
@@ -175,27 +175,26 @@ export const zhCNWebui = {
     matcherRuntimeControl: "运行时控制",
     matcherRuntimeNormal: "正常参与匹配",
     matcherRuntimeNormalDescription: "该 matcher 正在按照配置参与规则判断。",
-    matcherForceMiss: "强制不命中",
-    matcherForceMissDescription:
-      "该 matcher 的所有直接引用当前都不命中，内部匹配逻辑不会执行。",
-    matcherForceMissAction: "强制不命中",
-    matcherForceHit: "强制命中",
-    matcherForceHitDescription:
-      "该 matcher 的所有直接引用当前都会命中，内部匹配逻辑不会执行。",
-    matcherForceHitAction: "强制命中",
+    matcherAlwaysFalse: "固定为 false",
+    matcherAlwaysFalseDescription:
+      "该 matcher 的基础结果固定为 false；各引用仍会独立应用取反。",
+    matcherAlwaysFalseAction: "固定为 false",
+    matcherAlwaysTrue: "固定为 true",
+    matcherAlwaysTrueDescription:
+      "该 matcher 的基础结果固定为 true；各引用仍会独立应用取反。",
+    matcherAlwaysTrueAction: "固定为 true",
     matcherModeActions: "Matcher 运行模式",
     matcherRestoreAction: "恢复匹配",
-    matcherForceMissConfirmTitle: "将 {tag} 设为强制不命中？",
-    matcherForceMissConfirmDescription:
+    matcherAlwaysFalseConfirmTitle: "将 {tag} 的基础结果固定为 false？",
+    matcherAlwaysFalseConfirmDescription:
       "该操作会跳过内部匹配逻辑，只影响当前运行实例，不会修改配置。",
-    matcherForceMissImpact:
-      "直接引用 {positive} 和 {negative} 的条件都将不命中。",
-    matcherForceMissConfirmAction: "确认强制不命中",
-    matcherForceHitConfirmTitle: "将 {tag} 设为强制命中？",
-    matcherForceHitConfirmDescription:
-      "该操作会跳过内部匹配逻辑，可能同时触发多个策略分支，只影响当前运行实例。",
-    matcherForceHitImpact: "直接引用 {positive} 和 {negative} 的条件都将命中。",
-    matcherForceHitConfirmAction: "确认强制命中",
+    matcherAlwaysFalseImpact: "{positive} 将不命中，{negative} 取反后将命中。",
+    matcherAlwaysFalseConfirmAction: "确认固定为 false",
+    matcherAlwaysTrueConfirmTitle: "将 {tag} 的基础结果固定为 true？",
+    matcherAlwaysTrueConfirmDescription:
+      "该操作会跳过内部匹配逻辑，可能触发引用它的策略分支，只影响当前运行实例。",
+    matcherAlwaysTrueImpact: "{positive} 将命中，{negative} 取反后将不命中。",
+    matcherAlwaysTrueConfirmAction: "确认固定为 true",
     matcherModeResetHint: "应用 reload 或进程重启后自动恢复为正常匹配。",
     matcherControlLoading: "正在读取 matcher 运行状态",
     matcherControlUnavailable:
@@ -418,8 +417,10 @@ export const zhCNWebui = {
     eventCount: "{count} 个事件",
     matched: "命中",
     notMatched: "未命中",
-    forceHit: "强制命中",
-    forceMiss: "强制不命中",
+    alwaysTrueMatched: "固定 true · 命中",
+    alwaysTrueNotMatched: "固定 true · 取反未命中",
+    alwaysFalseMatched: "固定 false · 取反命中",
+    alwaysFalseNotMatched: "固定 false · 未命中",
     unchecked: "未检查",
     topologyUnavailable: "配置拓扑不可用，已按事件顺序降级显示",
     missingSequenceConfig: "缺少 sequence 配置：{names}",

--- a/webui/lib/matcher-control.test.ts
+++ b/webui/lib/matcher-control.test.ts
@@ -28,7 +28,7 @@ function plugin(
 }
 
 describe("matcher runtime state", () => {
-  it.each(["force_miss", "force_hit"] as const)(
+  it.each(["always_false", "always_true"] as const)(
     "requires confirmation before applying %s",
     (mode) => {
       expect(planMatcherModeChange(mode)).toEqual({ kind: "confirm", mode });
@@ -46,7 +46,7 @@ describe("matcher runtime state", () => {
     const ready: MatcherControlState = {
       availability: "ready",
       pending: false,
-      mode: "force_miss",
+      mode: "always_false",
     };
     const controls = reconcileMatcherControls(
       [

--- a/webui/lib/matcher-control.ts
+++ b/webui/lib/matcher-control.ts
@@ -1,12 +1,12 @@
 import type { PluginInstance } from "./types";
 
 export type MatcherControlAvailability = "loading" | "ready" | "unavailable";
-export type MatcherRuntimeMode = "normal" | "force_miss" | "force_hit";
-export type ForcedMatcherRuntimeMode = Exclude<MatcherRuntimeMode, "normal">;
+export type MatcherRuntimeMode = "normal" | "always_false" | "always_true";
+export type FixedMatcherRuntimeMode = Exclude<MatcherRuntimeMode, "normal">;
 
 export type MatcherModeChangePlan =
   | { kind: "apply"; mode: "normal" }
-  | { kind: "confirm"; mode: ForcedMatcherRuntimeMode };
+  | { kind: "confirm"; mode: FixedMatcherRuntimeMode };
 
 export interface MatcherControlState {
   availability: MatcherControlAvailability;


### PR DESCRIPTION
- Apply runtime overrides to the matcher base result before each reference applies `$tag` or `!$tag` negation.
- Rename runtime modes to `always_false` and `always_true`, and synchronize API, WebUI confirmations, icons, query records, and documentation.
- Add coverage for shared matcher controls across positive and negated references.

BREAKING CHANGE: replace `force_miss` and `force_hit` API modes with `always_false` and `always_true`.

Validated with Rust tests, Clippy, fmt, WebUI tests, typecheck, lint, and production build.