### PR TITLE
feat(dual-selector): add dedicated probe executor

### DIFF
--- a/docs/docs/plugin-reference/executor/response.mdx
+++ b/docs/docs/plugin-reference/executor/response.mdx
@@ -216,9 +216,17 @@ import Admonition from "@theme/Admonition";
 ### 配置示例
 
 ```yaml
+- tag: probe_v4
+  type: forward
+  args:
+    upstreams:
+      - addr: "udp://1.1.1.1:53"
+
 - tag: prefer_v4
   type: prefer_ipv4
   args:
+    # 可选：仅由 preferred QTYPE 内部探针执行
+    probe_executor: probe_v4
     # 记录 preferred 类型是否存在
     cache: true
     # preferred 状态缓存时长
@@ -226,6 +234,14 @@ import Admonition from "@theme/Admonition";
 ```
 
 ### 配置项
+
+#### `probe_executor`
+
+- 类型：`string`；必填：否；默认值：未配置
+- 作用：指定仅用于 preferred QTYPE 内部探针的 executor tag。填写不带 `$` 的普通 tag。
+- 可引用 `forward`、`sequence` 或其他能够独立生成 DNS response 的 executor。
+- 不支持字段内 quick setup。缺失引用、非 executor 引用、自引用和间接循环会在启动时由依赖图校验拒绝。
+- 未配置时保留原有 continuation 探针模式，已有配置无需修改。
 
 #### `cache`
 
@@ -247,8 +263,8 @@ import Admonition from "@theme/Admonition";
 
 说明：
 
-- quick setup 使用默认配置：`cache: true`、`cache_ttl: 3600`。
-- 如需关闭缓存或调整缓存时长，请使用完整插件配置。
+- quick setup 使用兼容模式及默认配置：不设置 `probe_executor`、`cache: true`、`cache_ttl: 3600`。
+- 如需指定专用探针 executor、关闭缓存或调整缓存时长，请使用完整插件配置。
 
 ### 行为说明
 
@@ -259,15 +275,19 @@ import Admonition from "@theme/Admonition";
 - 偏好类型请求正常放行，并记录“该域名存在 preferred answer”。
 - 非偏好类型请求：
   - 若缓存已知 preferred answer 存在，则直接返回空成功响应抑制该类型。
-  - 否则并发执行后续链路的原始查询和 preferred 类型探测，再决定是否抑制。
+  - 若缓存未命中，原始查询继续执行优选器之后的外层链路。
+  - 配置 `probe_executor` 时，preferred 类型探针仅执行指定 executor；未配置时，探针按兼容模式执行优选器之后的外层链路。
+  - preferred 探针包含对应类型答案时抑制原始类型；非截断 `NOERROR` 无对应答案或 `NXDOMAIN` 时明确采用原始结果。无响应、执行错误、超时、截断或其他失败 RCODE 属于未知状态，采用原始结果且不写入负缓存。
 
 ### 子查询与上下文隔离
 
 - preferred 类型查询是内部可用性探测，不是客户端请求的替代响应。探测命中后，外层仍保留原始 QTYPE，并为原始请求生成 `NOERROR/NODATA`。
-- 缓存未命中时，原始查询和 preferred 探测分别使用隔离的 `DnsContext` 执行后续链路。preferred 探测产生的 marks、runtime extensions 和执行路径事件不会合并回外层 context；因此，抑制发生后，外层 marks 与进入优选器时保持一致。
+- 缓存未命中时，原始查询和 preferred 探测分别使用隔离的 `DnsContext`。探测继承 ingress 和进入优选器前的 marks，但其 request、response、后续 marks、runtime extensions、执行路径及 `ExecStep` 均不会合并回外层 context；因此，抑制发生后，外层 marks 与进入优选器时保持一致。
 - preferred 探测无答案、失败或超时并采用原始查询结果时，原始子查询的完整结果（包括其 marks）会成为外层结果。
 - 该隔离规则使实时探测命中与缓存直接命中保持一致：两者都不会把 preferred 探测路径的状态暴露给外层后处理插件，也不应使用 marks 推断内部探测结果。
-- 缓存未命中的非偏好查询可能让优选器之后的链路执行两次。具有日志、计数、学习、脚本、Webhook 或其它非幂等副作用的执行器不应放在该探测链路中，除非配置者明确接受两次执行。
+- 未配置 `probe_executor` 的兼容模式可能让优选器之后的链路执行两次。具有日志、计数、学习、脚本、Webhook 或其它非幂等副作用的执行器不应放在该探测链路中，除非配置者明确接受两次执行。
+- 专用探针 executor 也应尽量保持无副作用。任务取消只能阻止尚未发生的工作，不能回滚已经完成的外部操作。
+- selector 缓存仍仅以域名为键。如果探针 sequence 依赖客户端、marks、随机、限流或其他请求级状态，应关闭 `cache`。
 
 ### 典型用途
 
@@ -276,7 +296,7 @@ import Admonition from "@theme/Admonition";
 
 <Admonition type="note" title="注意事项">
 
-- 该插件与 `forward` 联动最为紧密，通常放置在 `forward` 之前并通过 continuation 生效。
+- 推荐通过 `probe_executor` 引用专用 `forward` 或 `sequence`，避免探针重复执行外层后续链路。未配置时仍可放置在 `forward` 之前并通过 continuation 兼容生效。
 
 </Admonition>
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor/response.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor/response.mdx
@@ -217,9 +217,17 @@ Biases dual-stack results toward one address family.
 ### Example Configuration
 
 ```yaml
+- tag: probe_v4
+  type: forward
+  args:
+    upstreams:
+      - addr: "udp://1.1.1.1:53"
+
 - tag: prefer_v4
   type: prefer_ipv4
   args:
+    # Optional: execute only for the internal preferred-QTYPE probe
+    probe_executor: probe_v4
     # Cache whether the preferred family exists
     cache: true
     # Keep the preference cache for one hour
@@ -227,6 +235,14 @@ Biases dual-stack results toward one address family.
 ```
 
 ### Configuration Details
+
+#### `probe_executor`
+
+- Type: `string`; Required: no; Default: unset
+- Purpose: Specifies the executor tag used only for the internal preferred-QTYPE probe. Use a plain tag without `$`.
+- May reference `forward`, `sequence`, or another executor that can independently produce a DNS response.
+- Inline quick setup is not supported. The dependency graph rejects missing or non-executor references, self-references, and indirect cycles at startup.
+- When omitted, the existing continuation probe mode is preserved, so existing configurations need no changes.
 
 #### `cache`
 
@@ -248,8 +264,8 @@ Biases dual-stack results toward one address family.
 
 <Admonition type="note" title="Notes">
 
-- Quick setup uses the default configuration: `cache: true` and `cache_ttl: 3600`.
-- Use the full plugin configuration when disabling the cache or changing its TTL.
+- Quick setup uses compatibility mode and the defaults: no `probe_executor`, `cache: true`, and `cache_ttl: 3600`.
+- Use the full plugin configuration to select a dedicated probe executor, disable the cache, or change its TTL.
 
 </Admonition>
 
@@ -257,15 +273,19 @@ Biases dual-stack results toward one address family.
 
 - Helps make A and AAAA selection more stable when both families exist.
 - Preferred-family queries pass through normally and warm the preference cache when they return preferred-family answers.
-- Non-preferred-family queries are blocked immediately when the cache says the preferred family exists; otherwise `prefer_ipv4` / `prefer_ipv6` runs the downstream chain concurrently for the original query and a preferred-family probe.
+- Non-preferred-family queries are blocked immediately when the cache says the preferred family exists. On a cache miss, the original query continues through the outer downstream chain.
+- With `probe_executor`, the preferred-family probe runs only the selected executor. Without it, compatibility mode runs the outer downstream chain for the probe as well.
+- A preferred-family answer suppresses the original family. A non-truncated `NOERROR` without that answer or `NXDOMAIN` is a definitive miss and uses the original result. No response, execution error, timeout, truncation, or another failure RCODE is unknown, uses the original result, and does not write a negative cache entry.
 
 ### Subquery and Context Isolation
 
 - The preferred-family query is an internal availability probe, not a replacement response for the client request. When the probe succeeds, the outer context keeps the original QTYPE and generates a `NOERROR/NODATA` response for that request.
-- On a cache miss, the original query and the preferred-family probe run the downstream chain in isolated `DnsContext` instances. Marks, runtime extensions, and execution-path events produced by the preferred probe are not merged into the outer context; after suppression, the outer marks therefore remain as they were when the selector was entered.
+- On a cache miss, the original query and preferred-family probe use isolated `DnsContext` instances. The probe inherits ingress data and marks present before entering the selector, but its request, response, later marks, runtime extensions, execution path, and `ExecStep` are not merged into the outer context. After suppression, outer marks therefore remain as they were when the selector was entered.
 - If the preferred probe has no answer, fails, or times out and the original result is used, the complete original subquery result, including its marks, becomes the outer result.
 - This isolation keeps a live probe hit consistent with a direct cache hit: neither exposes preferred-probe state to outer post-processing plugins, and marks must not be used to infer internal probe outcomes.
-- A non-preferred cache miss may execute the chain after the selector twice. Do not place executors with logging, counting, learning, scripts, webhooks, or other non-idempotent side effects in that probe path unless duplicate execution is explicitly acceptable.
+- Compatibility mode without `probe_executor` may execute the chain after the selector twice. Do not place executors with logging, counting, learning, scripts, webhooks, or other non-idempotent side effects in that probe path unless duplicate execution is explicitly acceptable.
+- Keep a dedicated probe executor free of side effects where possible. Cancellation can prevent pending work, but it cannot roll back external operations that already completed.
+- The selector cache is still keyed only by domain name. Disable `cache` when a probe sequence depends on the client, marks, randomness, rate limits, or other request-scoped state.
 
 ### Typical Uses
 
@@ -275,6 +295,7 @@ Biases dual-stack results toward one address family.
 <Admonition type="note" title="Notes">
 
 - Preference is not a substitute for fixing broken transport paths.
+- Prefer a dedicated `forward` or `sequence` through `probe_executor` so the probe does not repeat the outer downstream chain. Omitting it retains continuation compatibility.
 
 </Admonition>
 

--- a/src/plugin/executor/dual_selector.rs
+++ b/src/plugin/executor/dual_selector.rs
@@ -10,6 +10,20 @@
 //!   1) block immediately when cache says preferred type exists.
 //!   2) otherwise run the downstream chain for the original query and a
 //!      preferred-type probe concurrently, then block/pass from those outcomes.
+//!      The probe can use a dedicated configured executor; without one it uses
+//!      the downstream continuation for backward compatibility.
+//!
+//! Configuration accepts optional `probe_executor`, `cache`, and `cache_ttl`
+//! fields. `probe_executor` is a plain executor tag resolved during startup;
+//! normal dependency validation rejects missing targets, kind mismatches, and
+//! cycles. No dependency resolution or config parsing occurs on the request
+//! path.
+//!
+//! The selector owns a bounded TTL cache and its cleanup task. A non-preferred
+//! cache miss starts at most one original task and one probe task, and every
+//! decision path joins or cancels both before returning. Probe context state is
+//! isolated, although external side effects completed by a probe cannot be
+//! rolled back.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -26,6 +40,7 @@ use crate::infra::cache::ttl::TtlCache;
 use crate::infra::clock::AppClock;
 use crate::infra::error::{DnsError, Result};
 use crate::infra::task as task_center;
+use crate::plugin::dependency::DependencySpec;
 use crate::plugin::executor::{ExecStep, Executor, ExecutorNext};
 use crate::plugin::{Plugin, PluginFactory, UninitializedPlugin};
 use crate::proto::{Rcode, RecordType};
@@ -41,6 +56,7 @@ const PROBE_WAIT_TIMEOUT: Duration = Duration::from_millis(500);
 struct DualSelector {
     tag: String,
     preferred_type: RecordType,
+    probe_executor: Option<Arc<dyn Executor>>,
     cache: TtlCache<String, Arc<CachedPreferredState>>,
     cache_enabled: bool,
     cache_ttl_ms: u64,
@@ -77,6 +93,8 @@ enum PreferredProbeOutcome {
 
 #[derive(Debug, Clone, Deserialize, Default)]
 struct DualSelectorConfig {
+    /// Optional executor used exclusively for preferred-type probes.
+    probe_executor: Option<String>,
     /// Enable preferred-result cache for non-preferred query short-circuiting.
     #[serde(default)]
     cache: Option<bool>,
@@ -229,9 +247,13 @@ impl DualSelector {
         {
             return continue_next!(Some(next), context);
         }
+        preferred_ctx.clear_response();
 
         let mut original_handle = spawn_subquery(next.clone(), original_ctx);
-        let mut preferred_handle = spawn_subquery(next, preferred_ctx);
+        let mut preferred_handle = match &self.probe_executor {
+            Some(probe_executor) => spawn_executor(probe_executor.clone(), preferred_ctx),
+            None => spawn_subquery(next, preferred_ctx),
+        };
 
         tokio::select! {
             original_join = &mut original_handle => {
@@ -240,6 +262,7 @@ impl DualSelector {
             preferred_join = &mut preferred_handle => {
                 match self.preferred_probe_outcome(preferred_join, domain) {
                     PreferredProbeOutcome::HasPreferredAnswer => {
+                        abort_and_reap(original_handle).await;
                         context.set_response(context.request().response(Rcode::NoError));
                         Ok(ExecStep::Stop)
                     }
@@ -256,14 +279,18 @@ impl DualSelector {
         context: &mut DnsContext,
         domain: &str,
         original_join: std::result::Result<SubqueryOutcome, JoinError>,
-        preferred_handle: JoinHandle<SubqueryOutcome>,
+        mut preferred_handle: JoinHandle<SubqueryOutcome>,
     ) -> Result<ExecStep> {
-        if let Ok(preferred_join) = tokio::time::timeout(PROBE_WAIT_TIMEOUT, preferred_handle).await
-            && self.preferred_probe_outcome(preferred_join, domain)
-                == PreferredProbeOutcome::HasPreferredAnswer
-        {
-            context.set_response(context.request().response(Rcode::NoError));
-            return Ok(ExecStep::Stop);
+        match tokio::time::timeout(PROBE_WAIT_TIMEOUT, &mut preferred_handle).await {
+            Ok(preferred_join) => {
+                if self.preferred_probe_outcome(preferred_join, domain)
+                    == PreferredProbeOutcome::HasPreferredAnswer
+                {
+                    context.set_response(context.request().response(Rcode::NoError));
+                    return Ok(ExecStep::Stop);
+                }
+            }
+            Err(_) => abort_and_reap(preferred_handle).await,
         }
 
         self.finish_with_original(context, original_join)
@@ -288,20 +315,26 @@ impl DualSelector {
             return PreferredProbeOutcome::Unknown;
         };
 
-        if preferred_ctx
-            .response()
-            .is_some_and(|response| response.has_answer_type(self.preferred_type))
-        {
+        let Some(response) = preferred_ctx.response() else {
+            return PreferredProbeOutcome::Unknown;
+        };
+        if response.truncated() {
+            return PreferredProbeOutcome::Unknown;
+        }
+        if response.has_answer_type(self.preferred_type) {
             if self.cache_enabled {
                 self.cache_probe_result(domain, true);
             }
             return PreferredProbeOutcome::HasPreferredAnswer;
         }
 
-        if self.cache_enabled {
-            self.cache_probe_result(domain, false);
+        if response.rcode() == Rcode::NoError || response.rcode() == Rcode::NXDomain {
+            if self.cache_enabled {
+                self.cache_probe_result(domain, false);
+            }
+            return PreferredProbeOutcome::NoPreferredAnswer;
         }
-        PreferredProbeOutcome::NoPreferredAnswer
+        PreferredProbeOutcome::Unknown
     }
 
     fn cache_preferred(&self, domain: &str) {
@@ -337,6 +370,21 @@ fn spawn_subquery(next: ExecutorNext, mut context: DnsContext) -> JoinHandle<Sub
     })
 }
 
+fn spawn_executor(
+    executor: Arc<dyn Executor>,
+    mut context: DnsContext,
+) -> JoinHandle<SubqueryOutcome> {
+    tokio::spawn(async move {
+        let step = executor.execute_with_next(&mut context, None).await;
+        (context, step)
+    })
+}
+
+async fn abort_and_reap(handle: JoinHandle<SubqueryOutcome>) {
+    handle.abort();
+    let _ = handle.await;
+}
+
 fn join_error(err: JoinError) -> DnsError {
     DnsError::runtime(format!("dual_selector subquery join failed: {err}"))
 }
@@ -355,13 +403,32 @@ impl DualSelectorFactory {
     }
 }
 
-fn parse_dual_selector_config(args: Option<Value>) -> Result<(bool, u64)> {
+#[derive(Debug)]
+struct ParsedDualSelectorConfig {
+    probe_executor: Option<String>,
+    cache_enabled: bool,
+    cache_ttl_ms: u64,
+}
+
+fn parse_dual_selector_config(args: Option<Value>) -> Result<ParsedDualSelectorConfig> {
     let cfg = match args {
         Some(args) => serde_yaml_ng::from_value::<DualSelectorConfig>(args).map_err(|e| {
             DnsError::plugin(format!("failed to parse dual_selector config: {}", e))
         })?,
         None => DualSelectorConfig::default(),
     };
+
+    let configured_probe_executor = cfg.probe_executor;
+    let probe_executor = configured_probe_executor
+        .as_deref()
+        .map(str::trim)
+        .filter(|tag| !tag.is_empty());
+    if configured_probe_executor.is_some() && probe_executor.is_none() {
+        return Err(DnsError::plugin(
+            "dual_selector probe_executor cannot be empty",
+        ));
+    }
+    let probe_executor = probe_executor.map(ToOwned::to_owned);
 
     let cache_enabled = cfg.cache.unwrap_or(DEFAULT_CACHE_ENABLED);
     let cache_ttl_secs = cfg.cache_ttl.unwrap_or(DEFAULT_CACHE_TTL_SECS);
@@ -375,22 +442,42 @@ fn parse_dual_selector_config(args: Option<Value>) -> Result<(bool, u64)> {
     } else {
         cache_ttl_secs.saturating_mul(1000)
     };
-    Ok((cache_enabled, cache_ttl_ms))
+    Ok(ParsedDualSelectorConfig {
+        probe_executor,
+        cache_enabled,
+        cache_ttl_ms,
+    })
 }
 
 impl PluginFactory for DualSelectorFactory {
+    fn get_dependency_specs(&self, plugin_config: &PluginConfig) -> Vec<DependencySpec> {
+        plugin_config
+            .args
+            .clone()
+            .and_then(|args| serde_yaml_ng::from_value::<DualSelectorConfig>(args).ok())
+            .and_then(|cfg| cfg.probe_executor)
+            .map(|tag| vec![DependencySpec::executor("args.probe_executor", tag)])
+            .unwrap_or_default()
+    }
+
     fn create(
         &self,
         plugin_config: &PluginConfig,
-        _init_context: &crate::plugin::PluginInitContext<'_>,
+        init_context: &crate::plugin::PluginInitContext<'_>,
     ) -> Result<UninitializedPlugin> {
-        let (cache_enabled, cache_ttl_ms) = parse_dual_selector_config(plugin_config.args.clone())?;
+        let cfg = parse_dual_selector_config(plugin_config.args.clone())?;
+        let probe_executor = cfg
+            .probe_executor
+            .as_deref()
+            .map(|tag| init_context.executor("args.probe_executor", tag))
+            .transpose()?;
         Ok(UninitializedPlugin::Executor(Box::new(DualSelector {
             tag: plugin_config.tag.clone(),
             preferred_type: self.record_type,
+            probe_executor,
             cache: TtlCache::with_capacity(4096),
-            cache_enabled,
-            cache_ttl_ms,
+            cache_enabled: cfg.cache_enabled,
+            cache_ttl_ms: cfg.cache_ttl_ms,
             cleanup_started: AtomicBool::new(false),
             cleanup_task_id: None,
         })))
@@ -400,6 +487,7 @@ impl PluginFactory for DualSelectorFactory {
         Ok(UninitializedPlugin::Executor(Box::new(DualSelector {
             tag: tag.to_string(),
             preferred_type: self.record_type,
+            probe_executor: None,
             cache: TtlCache::with_capacity(4096),
             cache_enabled: DEFAULT_CACHE_ENABLED,
             cache_ttl_ms: DEFAULT_CACHE_TTL_MS,
@@ -412,7 +500,7 @@ impl PluginFactory for DualSelectorFactory {
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use super::*;
     use crate::plugin::executor::sequence::chain::ChainProgram;
@@ -434,12 +522,22 @@ mod tests {
         DualSelector {
             tag: "dual_selector_test".to_string(),
             preferred_type,
+            probe_executor: None,
             cache: TtlCache::with_capacity(1024),
             cache_enabled: true,
             cache_ttl_ms: DEFAULT_CACHE_TTL_MS,
             cleanup_started: AtomicBool::new(false),
             cleanup_task_id: None,
         }
+    }
+
+    fn make_selector_with_probe(
+        preferred_type: RecordType,
+        probe_executor: Arc<dyn Executor>,
+    ) -> DualSelector {
+        let mut selector = make_selector(preferred_type);
+        selector.probe_executor = Some(probe_executor);
+        selector
     }
 
     fn set_answer(context: &mut DnsContext, qtype: RecordType) {
@@ -483,6 +581,8 @@ mod tests {
         delay_aaaa: Duration,
         error_a: Option<&'static str>,
         error_aaaa: Option<&'static str>,
+        mark_a: Option<u32>,
+        mark_aaaa: Option<u32>,
         calls: Arc<AtomicUsize>,
     }
 
@@ -495,6 +595,8 @@ mod tests {
                 delay_aaaa: Duration::ZERO,
                 error_a: None,
                 error_aaaa: None,
+                mark_a: None,
+                mark_aaaa: None,
                 calls: Arc::new(AtomicUsize::new(0)),
             }
         }
@@ -531,6 +633,9 @@ mod tests {
                     if let Some(err) = self.error_a {
                         return Err(DnsError::plugin(err));
                     }
+                    if let Some(mark) = self.mark_a {
+                        context.marks_mut().insert(mark);
+                    }
                     if self.answer_a {
                         set_answer(context, RecordType::A);
                     } else {
@@ -544,6 +649,9 @@ mod tests {
                     if let Some(err) = self.error_aaaa {
                         return Err(DnsError::plugin(err));
                     }
+                    if let Some(mark) = self.mark_aaaa {
+                        context.marks_mut().insert(mark);
+                    }
                     if self.answer_aaaa {
                         set_answer(context, RecordType::AAAA);
                     } else {
@@ -552,6 +660,186 @@ mod tests {
                 }
                 _ => {}
             }
+            Ok(ExecStep::Next)
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum ProbeResponse {
+        Answer,
+        NoData,
+        NxDomain,
+        ServFail,
+        Truncated,
+        NoResponse,
+        Error,
+    }
+
+    #[derive(Debug)]
+    struct DedicatedProbeExecutor {
+        response: ProbeResponse,
+        mark: Option<u32>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl DedicatedProbeExecutor {
+        fn new(response: ProbeResponse) -> Self {
+            Self {
+                response,
+                mark: None,
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn calls(&self) -> Arc<AtomicUsize> {
+            self.calls.clone()
+        }
+    }
+
+    #[async_trait]
+    impl Plugin for DedicatedProbeExecutor {
+        fn tag(&self) -> &str {
+            "dedicated_probe"
+        }
+    }
+
+    #[async_trait]
+    impl Executor for DedicatedProbeExecutor {
+        async fn execute(&self, context: &mut DnsContext) -> Result<ExecStep> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(mark) = self.mark {
+                context.marks_mut().insert(mark);
+            }
+            match self.response {
+                ProbeResponse::Answer => {
+                    let qtype = context
+                        .request()
+                        .first_qtype()
+                        .expect("probe request should have qtype");
+                    set_answer(context, qtype);
+                }
+                ProbeResponse::NoData => {
+                    context.set_response(context.request().response(Rcode::NoError));
+                }
+                ProbeResponse::NxDomain => {
+                    context.set_response(context.request().response(Rcode::NXDomain));
+                }
+                ProbeResponse::ServFail => {
+                    context.set_response(context.request().response(Rcode::ServFail));
+                }
+                ProbeResponse::Truncated => {
+                    let mut response = context.request().response(Rcode::NoError);
+                    response.set_truncated(true);
+                    context.set_response(response);
+                }
+                ProbeResponse::NoResponse => {}
+                ProbeResponse::Error => return Err(DnsError::plugin("probe failed")),
+            }
+            Ok(ExecStep::Next)
+        }
+    }
+
+    struct CancellationGuard {
+        cancelled: Arc<AtomicBool>,
+        completed: bool,
+    }
+
+    impl CancellationGuard {
+        fn new(cancelled: Arc<AtomicBool>) -> Self {
+            Self {
+                cancelled,
+                completed: false,
+            }
+        }
+
+        fn complete(&mut self) {
+            self.completed = true;
+        }
+    }
+
+    impl Drop for CancellationGuard {
+        fn drop(&mut self) {
+            if !self.completed {
+                self.cancelled.store(true, Ordering::SeqCst);
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct OriginalCancellationExecutor {
+        original_started: Arc<AtomicBool>,
+        original_cancelled: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Plugin for OriginalCancellationExecutor {
+        fn tag(&self) -> &str {
+            "original_cancellation"
+        }
+    }
+
+    #[async_trait]
+    impl Executor for OriginalCancellationExecutor {
+        async fn execute(&self, context: &mut DnsContext) -> Result<ExecStep> {
+            if context.request().first_qtype() == Some(RecordType::AAAA) {
+                self.original_started.store(true, Ordering::SeqCst);
+                let mut guard = CancellationGuard::new(self.original_cancelled.clone());
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                guard.complete();
+                set_answer(context, RecordType::AAAA);
+            } else {
+                while !self.original_started.load(Ordering::SeqCst) {
+                    tokio::task::yield_now().await;
+                }
+                set_answer(context, RecordType::A);
+            }
+            Ok(ExecStep::Next)
+        }
+    }
+
+    #[derive(Debug)]
+    struct HangingProbeExecutor {
+        started: Arc<AtomicBool>,
+        cancelled: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Plugin for HangingProbeExecutor {
+        fn tag(&self) -> &str {
+            "hanging_probe"
+        }
+    }
+
+    #[async_trait]
+    impl Executor for HangingProbeExecutor {
+        async fn execute(&self, _context: &mut DnsContext) -> Result<ExecStep> {
+            self.started.store(true, Ordering::SeqCst);
+            let mut guard = CancellationGuard::new(self.cancelled.clone());
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            guard.complete();
+            Ok(ExecStep::Next)
+        }
+    }
+
+    #[derive(Debug)]
+    struct WaitForProbeOriginalExecutor {
+        probe_started: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Plugin for WaitForProbeOriginalExecutor {
+        fn tag(&self) -> &str {
+            "wait_for_probe_original"
+        }
+    }
+
+    #[async_trait]
+    impl Executor for WaitForProbeOriginalExecutor {
+        async fn execute(&self, context: &mut DnsContext) -> Result<ExecStep> {
+            while !self.probe_started.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+            set_answer(context, RecordType::AAAA);
             Ok(ExecStep::Next)
         }
     }
@@ -601,6 +889,208 @@ mod tests {
             &non_preferred_context,
             RecordType::AAAA
         ));
+    }
+
+    #[tokio::test]
+    async fn dedicated_probe_suppresses_without_leaking_probe_marks() {
+        AppClock::start();
+        let mut probe = DedicatedProbeExecutor::new(ProbeResponse::Answer);
+        probe.mark = Some(20);
+        let probe_calls = probe.calls();
+        let selector = make_selector_with_probe(RecordType::A, Arc::new(probe));
+        let mut context = make_context(RecordType::AAAA);
+        context.marks_mut().insert(1);
+        let mut original = StubNextExecutor::new(false, true);
+        original.delay_aaaa = Duration::from_millis(100);
+        original.mark_aaaa = Some(10);
+
+        let step = run_selector(&selector, &mut context, Some(make_next(Arc::new(original))))
+            .await
+            .unwrap();
+
+        assert_eq!(step, ExecStep::Stop);
+        assert_eq!(context.request().first_qtype(), Some(RecordType::AAAA));
+        let response = context.response().expect("selector should suppress AAAA");
+        assert_eq!(response.rcode(), Rcode::NoError);
+        assert!(response.answers().is_empty());
+        assert!(context.marks().contains(&1));
+        assert!(!context.marks().contains(&10));
+        assert!(!context.marks().contains(&20));
+        assert_eq!(probe_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn dedicated_probe_does_not_repeat_outer_continuation() {
+        AppClock::start();
+        let probe = DedicatedProbeExecutor::new(ProbeResponse::NoData);
+        let probe_calls = probe.calls();
+        let selector = make_selector_with_probe(RecordType::A, Arc::new(probe));
+        let mut context = make_context(RecordType::AAAA);
+        let original = StubNextExecutor::new(false, true);
+        let original_calls = original.calls();
+
+        let step = run_selector(&selector, &mut context, Some(make_next(Arc::new(original))))
+            .await
+            .unwrap();
+
+        assert_eq!(step, ExecStep::Next);
+        assert!(has_answer_of_type(&context, RecordType::AAAA));
+        assert_eq!(original_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(probe_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn preferred_query_does_not_run_dedicated_probe() {
+        AppClock::start();
+        let probe = DedicatedProbeExecutor::new(ProbeResponse::Answer);
+        let probe_calls = probe.calls();
+        let selector = make_selector_with_probe(RecordType::A, Arc::new(probe));
+        let mut context = make_context(RecordType::A);
+        let original = StubNextExecutor::new(true, false);
+        let original_calls = original.calls();
+
+        let step = run_selector(&selector, &mut context, Some(make_next(Arc::new(original))))
+            .await
+            .unwrap();
+
+        assert_eq!(step, ExecStep::Next);
+        assert!(has_answer_of_type(&context, RecordType::A));
+        assert_eq!(original_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(probe_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn dedicated_probe_unknown_adopts_original_context_and_marks() {
+        AppClock::start();
+        let mut probe = DedicatedProbeExecutor::new(ProbeResponse::ServFail);
+        probe.mark = Some(20);
+        let selector = make_selector_with_probe(RecordType::A, Arc::new(probe));
+        let mut context = make_context(RecordType::AAAA);
+        context.marks_mut().insert(1);
+        let mut original = StubNextExecutor::new(false, true);
+        original.mark_aaaa = Some(10);
+
+        let step = run_selector(&selector, &mut context, Some(make_next(Arc::new(original))))
+            .await
+            .unwrap();
+
+        assert_eq!(step, ExecStep::Next);
+        assert!(has_answer_of_type(&context, RecordType::AAAA));
+        assert!(context.marks().contains(&1));
+        assert!(context.marks().contains(&10));
+        assert!(!context.marks().contains(&20));
+    }
+
+    #[tokio::test]
+    async fn dedicated_probe_definitive_absence_is_cached() {
+        for response in [ProbeResponse::NoData, ProbeResponse::NxDomain] {
+            AppClock::start();
+            let probe = DedicatedProbeExecutor::new(response);
+            let probe_calls = probe.calls();
+            let selector = make_selector_with_probe(RecordType::A, Arc::new(probe));
+
+            for _ in 0..2 {
+                let mut context = make_context(RecordType::AAAA);
+                let original = StubNextExecutor::new(false, true);
+                let step =
+                    run_selector(&selector, &mut context, Some(make_next(Arc::new(original))))
+                        .await
+                        .unwrap();
+                assert_eq!(step, ExecStep::Next);
+                assert!(has_answer_of_type(&context, RecordType::AAAA));
+            }
+
+            assert_eq!(probe_calls.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn dedicated_probe_unknown_outcomes_are_not_cached() {
+        for response in [
+            ProbeResponse::ServFail,
+            ProbeResponse::Truncated,
+            ProbeResponse::NoResponse,
+            ProbeResponse::Error,
+        ] {
+            AppClock::start();
+            let probe = DedicatedProbeExecutor::new(response);
+            let probe_calls = probe.calls();
+            let selector = make_selector_with_probe(RecordType::A, Arc::new(probe));
+
+            for _ in 0..2 {
+                let mut context = make_context(RecordType::AAAA);
+                let original = StubNextExecutor::new(false, true);
+                run_selector(&selector, &mut context, Some(make_next(Arc::new(original))))
+                    .await
+                    .unwrap();
+                assert!(has_answer_of_type(&context, RecordType::AAAA));
+            }
+
+            assert_eq!(probe_calls.load(Ordering::SeqCst), 2);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn preferred_winner_cancels_and_reaps_original_task() {
+        AppClock::start();
+        let original_started = Arc::new(AtomicBool::new(false));
+        let original_cancelled = Arc::new(AtomicBool::new(false));
+        let executor = OriginalCancellationExecutor {
+            original_started,
+            original_cancelled: original_cancelled.clone(),
+        };
+        let selector = make_selector(RecordType::A);
+        let mut context = make_context(RecordType::AAAA);
+
+        let step = run_selector(&selector, &mut context, Some(make_next(Arc::new(executor))))
+            .await
+            .unwrap();
+
+        assert_eq!(step, ExecStep::Stop);
+        assert!(original_cancelled.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn probe_timeout_cancels_and_reaps_probe_task() {
+        AppClock::start();
+        let probe_started = Arc::new(AtomicBool::new(false));
+        let probe_cancelled = Arc::new(AtomicBool::new(false));
+        let probe = HangingProbeExecutor {
+            started: probe_started.clone(),
+            cancelled: probe_cancelled.clone(),
+        };
+        let selector = make_selector_with_probe(RecordType::A, Arc::new(probe));
+        let original = WaitForProbeOriginalExecutor { probe_started };
+        let mut context = make_context(RecordType::AAAA);
+
+        let step = run_selector(&selector, &mut context, Some(make_next(Arc::new(original))))
+            .await
+            .unwrap();
+
+        assert_eq!(step, ExecStep::Next);
+        assert!(has_answer_of_type(&context, RecordType::AAAA));
+        assert!(probe_cancelled.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn dedicated_probe_supports_prefer_ipv6_symmetrically() {
+        AppClock::start();
+        let probe = DedicatedProbeExecutor::new(ProbeResponse::Answer);
+        let selector = make_selector_with_probe(RecordType::AAAA, Arc::new(probe));
+        let mut context = make_context(RecordType::A);
+        let original = StubNextExecutor::new(true, false);
+
+        let step = run_selector(&selector, &mut context, Some(make_next(Arc::new(original))))
+            .await
+            .unwrap();
+
+        assert_eq!(step, ExecStep::Stop);
+        assert_eq!(context.request().first_qtype(), Some(RecordType::A));
+        assert!(
+            context
+                .response()
+                .is_some_and(|response| response.answers().is_empty())
+        );
     }
 
     #[tokio::test]

--- a/src/plugin/executor/dual_selector.rs
+++ b/src/plugin/executor/dual_selector.rs
@@ -32,7 +32,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_yaml_ng::Value;
-use tokio::task::{JoinError, JoinHandle};
+use tokio::task::JoinError;
+use tokio_util::task::AbortOnDropHandle;
 
 use crate::config::types::PluginConfig;
 use crate::core::context::DnsContext;
@@ -83,6 +84,7 @@ enum ExecPlan {
 }
 
 type SubqueryOutcome = (DnsContext, Result<ExecStep>);
+type SubqueryHandle = AbortOnDropHandle<SubqueryOutcome>;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum PreferredProbeOutcome {
@@ -279,7 +281,7 @@ impl DualSelector {
         context: &mut DnsContext,
         domain: &str,
         original_join: std::result::Result<SubqueryOutcome, JoinError>,
-        mut preferred_handle: JoinHandle<SubqueryOutcome>,
+        mut preferred_handle: SubqueryHandle,
     ) -> Result<ExecStep> {
         match tokio::time::timeout(PROBE_WAIT_TIMEOUT, &mut preferred_handle).await {
             Ok(preferred_join) => {
@@ -363,26 +365,23 @@ impl DualSelector {
     }
 }
 
-fn spawn_subquery(next: ExecutorNext, mut context: DnsContext) -> JoinHandle<SubqueryOutcome> {
-    tokio::spawn(async move {
+fn spawn_subquery(next: ExecutorNext, mut context: DnsContext) -> SubqueryHandle {
+    AbortOnDropHandle::new(tokio::spawn(async move {
         let step = next.next(&mut context).await;
         (context, step)
-    })
+    }))
 }
 
-fn spawn_executor(
-    executor: Arc<dyn Executor>,
-    mut context: DnsContext,
-) -> JoinHandle<SubqueryOutcome> {
-    tokio::spawn(async move {
+fn spawn_executor(executor: Arc<dyn Executor>, mut context: DnsContext) -> SubqueryHandle {
+    AbortOnDropHandle::new(tokio::spawn(async move {
         let step = executor.execute_with_next(&mut context, None).await;
         (context, step)
-    })
+    }))
 }
 
-async fn abort_and_reap(handle: JoinHandle<SubqueryOutcome>) {
+async fn abort_and_reap(mut handle: SubqueryHandle) {
     handle.abort();
-    let _ = handle.await;
+    let _ = (&mut handle).await;
 }
 
 fn join_error(err: JoinError) -> DnsError {
@@ -813,8 +812,8 @@ mod tests {
     #[async_trait]
     impl Executor for HangingProbeExecutor {
         async fn execute(&self, _context: &mut DnsContext) -> Result<ExecStep> {
-            self.started.store(true, Ordering::SeqCst);
             let mut guard = CancellationGuard::new(self.cancelled.clone());
+            self.started.store(true, Ordering::SeqCst);
             tokio::time::sleep(Duration::from_secs(60)).await;
             guard.complete();
             Ok(ExecStep::Next)
@@ -1070,6 +1069,52 @@ mod tests {
         assert_eq!(step, ExecStep::Next);
         assert!(has_answer_of_type(&context, RecordType::AAAA));
         assert!(probe_cancelled.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn parent_cancellation_aborts_original_and_probe_tasks() {
+        AppClock::start();
+        let original_started = Arc::new(AtomicBool::new(false));
+        let original_cancelled = Arc::new(AtomicBool::new(false));
+        let original = HangingProbeExecutor {
+            started: original_started.clone(),
+            cancelled: original_cancelled.clone(),
+        };
+        let probe_started = Arc::new(AtomicBool::new(false));
+        let probe_cancelled = Arc::new(AtomicBool::new(false));
+        let probe = HangingProbeExecutor {
+            started: probe_started.clone(),
+            cancelled: probe_cancelled.clone(),
+        };
+        let selector = make_selector_with_probe(RecordType::A, Arc::new(probe));
+
+        let parent = tokio::spawn(async move {
+            let mut context = make_context(RecordType::AAAA);
+            run_selector(&selector, &mut context, Some(make_next(Arc::new(original)))).await
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !original_started.load(Ordering::SeqCst) || !probe_started.load(Ordering::SeqCst)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("both subqueries should start");
+
+        parent.abort();
+        let parent_result = parent.await;
+        assert!(parent_result.is_err_and(|err| err.is_cancelled()));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !original_cancelled.load(Ordering::SeqCst)
+                || !probe_cancelled.load(Ordering::SeqCst)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("both subqueries should be cancelled with their parent");
     }
 
     #[tokio::test]

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -868,6 +868,182 @@ plugins:
 }
 
 #[tokio::test]
+async fn test_dual_selector_uses_dedicated_probe_executor_and_isolates_marks() -> Result<()> {
+    let yaml = r#"
+log:
+  level: info
+plugins:
+  - tag: probe_hosts
+    type: hosts
+    args:
+      entries:
+        - "full:example.com 192.0.2.10"
+  - tag: prefer_v4
+    type: prefer_ipv4
+    args:
+      probe_executor: probe_hosts
+      cache: false
+  - tag: main
+    type: sequence
+    args:
+      - exec: mark 1
+      - exec: $prefer_v4
+      - exec: mark 10
+      - exec: reject SERVFAIL
+"#;
+
+    let config = parse_config(yaml)?;
+    let report = plugin::analyze_configuration(&config)?;
+    assert!(report.edges.iter().any(|edge| {
+        edge.source_tag == "prefer_v4"
+            && edge.target_tag == "probe_hosts"
+            && edge.field == "args.probe_executor"
+    }));
+
+    let registry = plugin::init(config).await?;
+    let sequence = registry
+        .get_plugin("main")
+        .expect("main sequence should exist")
+        .to_executor();
+    let mut context = make_context_with_qtype(registry.clone(), "example.com.", RecordType::AAAA);
+
+    let step = sequence.execute(&mut context).await?;
+
+    assert_eq!(step, ExecStep::Stop);
+    assert_eq!(context.request().first_qtype(), Some(RecordType::AAAA));
+    let response = context
+        .response()
+        .expect("preferred probe should suppress AAAA");
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert!(response.answers().is_empty());
+    assert!(context.marks().contains(&1));
+    assert!(!context.marks().contains(&10));
+
+    registry.destroy().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_dual_selector_accepts_sequence_as_dedicated_probe_executor() -> Result<()> {
+    let yaml = r#"
+log:
+  level: info
+plugins:
+  - tag: probe_hosts
+    type: hosts
+    args:
+      entries:
+        - "full:example.com 192.0.2.10"
+  - tag: probe_sequence
+    type: sequence
+    args:
+      - exec: mark 20
+      - exec: $probe_hosts
+  - tag: prefer_v4
+    type: prefer_ipv4
+    args:
+      probe_executor: probe_sequence
+      cache: false
+  - tag: main
+    type: sequence
+    args:
+      - exec: mark 1
+      - exec: $prefer_v4
+      - exec: mark 10
+      - exec: reject SERVFAIL
+"#;
+
+    let config = parse_config(yaml)?;
+    let registry = plugin::init(config).await?;
+    let sequence = registry
+        .get_plugin("main")
+        .expect("main sequence should exist")
+        .to_executor();
+    let mut context = make_context_with_qtype(registry.clone(), "example.com.", RecordType::AAAA);
+
+    sequence.execute(&mut context).await?;
+
+    assert_eq!(
+        context
+            .response()
+            .expect("preferred probe should suppress AAAA")
+            .rcode(),
+        Rcode::NoError
+    );
+    assert!(context.marks().contains(&1));
+    assert!(!context.marks().contains(&10));
+    assert!(!context.marks().contains(&20));
+
+    registry.destroy().await;
+    Ok(())
+}
+
+#[test]
+fn test_dual_selector_probe_executor_dependency_validation() -> Result<()> {
+    let missing = parse_config(
+        r#"
+plugins:
+  - tag: prefer_v4
+    type: prefer_ipv4
+    args:
+      probe_executor: missing
+"#,
+    )?;
+    let err = plugin::analyze_configuration(&missing)
+        .expect_err("missing probe executor should fail dependency analysis");
+    assert!(err.to_string().contains("missing plugin 'missing'"));
+    assert!(err.to_string().contains("args.probe_executor"));
+
+    let wrong_kind = parse_config(
+        r#"
+plugins:
+  - tag: not_executor
+    type: _true
+  - tag: prefer_v4
+    type: prefer_ipv4
+    args:
+      probe_executor: not_executor
+"#,
+    )?;
+    let err = plugin::analyze_configuration(&wrong_kind)
+        .expect_err("non-executor probe target should fail dependency analysis");
+    assert!(err.to_string().contains("expects executor"));
+    assert!(err.to_string().contains("not_executor"));
+
+    let self_reference = parse_config(
+        r#"
+plugins:
+  - tag: prefer_v4
+    type: prefer_ipv4
+    args:
+      probe_executor: prefer_v4
+"#,
+    )?;
+    let err = plugin::analyze_configuration(&self_reference)
+        .expect_err("self-referenced probe executor should fail dependency analysis");
+    assert!(err.to_string().contains("references itself"));
+
+    let cycle = parse_config(
+        r#"
+plugins:
+  - tag: prefer_a
+    type: prefer_ipv4
+    args:
+      probe_executor: prefer_b
+  - tag: prefer_b
+    type: prefer_ipv6
+    args:
+      probe_executor: prefer_a
+"#,
+    )?;
+    let err = plugin::analyze_configuration(&cycle)
+        .expect_err("probe executor cycle should fail dependency analysis");
+    assert!(err.to_string().contains("Circular dependency detected"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_sequence_supports_single_match_string_dependency_and_execution() -> Result<()> {
     let yaml = r#"
 log:

--- a/webui/components/plugins/plugin-config-fields-editor.test.ts
+++ b/webui/components/plugins/plugin-config-fields-editor.test.ts
@@ -64,9 +64,17 @@ const forwardDefinition = executorPluginDefinitions.find(
 const fallbackDefinition = executorPluginDefinitions.find(
   (definition) => definition.kind === "fallback",
 );
+const preferDefinitions = executorPluginDefinitions.filter(
+  (definition) =>
+    definition.kind === "prefer_ipv4" || definition.kind === "prefer_ipv6",
+);
 
 if (!forwardDefinition || !fallbackDefinition) {
   throw new Error("forward and fallback executor definitions must exist");
+}
+
+if (preferDefinitions.length !== 2) {
+  throw new Error("both dual selector executor definitions must exist");
 }
 
 describe("time matcher config form", () => {
@@ -221,6 +229,21 @@ describe("optional object config fields", () => {
       expect(
         serializePluginConfigValues(definition.configSchema, values),
       ).toHaveProperty("tls", {});
+    }
+  });
+});
+
+describe("optional reference config fields", () => {
+  it("omits a cleared dual selector probe executor", () => {
+    for (const definition of preferDefinitions) {
+      const values = createPluginConfigFormValues(definition.configSchema, {
+        probe_executor: "probe_forward",
+      });
+      values.probe_executor = "";
+
+      expect(
+        serializePluginConfigValues(definition.configSchema, values),
+      ).not.toHaveProperty("probe_executor");
     }
   });
 });

--- a/webui/components/plugins/plugin-config-fields-editor.tsx
+++ b/webui/components/plugins/plugin-config-fields-editor.tsx
@@ -35,7 +35,7 @@ import type { PluginInstance, PluginType } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { WEBUI } from "@/lib/i18n";
 import { useI18n } from "@/lib/i18n/provider";
-import { ChevronDown, Info, Minus, Plus } from "lucide-react";
+import { ChevronDown, Info, Minus, Plus, X } from "lucide-react";
 import {
   Fragment,
   useEffect,
@@ -942,6 +942,25 @@ function ConfigFieldControl({
               )
             }
           />
+          {!field.required && referenceValue && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-lg"
+                  disabled={readOnly}
+                  aria-label={t(WEBUI.plugins.clearSelection)}
+                  onClick={() => onChange("")}
+                >
+                  <X />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent sideOffset={6}>
+                {t(WEBUI.plugins.clearSelection)}
+              </TooltipContent>
+            </Tooltip>
+          )}
         </div>
       );
     default:

--- a/webui/lib/i18n/locales/en-US/docs.ts
+++ b/webui/lib/i18n/locales/en-US/docs.ts
@@ -219,12 +219,16 @@ export const enUSDocs = {
       "- Type: `integer`; required: no; default value: `60`\n- Unit: seconds\n- Function: Define the retention time of failed detection scores.\n- Configuration requirements: Must be greater than 0 when caching is enabled.\n- Operational impact: Failure caching can prevent unreachable addresses from being repeatedly detected in a short period of time, while allowing faster recovery.",
   },
   prefer_ipv4: {
+    probe_executor:
+      "- Type: `string`; required: no; default: unset (compatibility continuation probe mode)\n- Purpose: References an executor used only for the internal preferred-QTYPE probe. Enter a plain executor tag without `$`.\n- Runtime impact: May reference `forward`, `sequence`, or another executor that can independently produce a DNS response. Probe marks, extensions, and execution-path state stay isolated from the outer context.\n- Cache limitation: Disable `cache` when the probe result depends on the client, marks, randomness, rate limits, or other request-scoped state.",
     cache:
       "- Type: `boolean`; required: no; default value: `true`\n- Function: Control whether to cache the preferred type existence status.",
     cache_ttl:
       "- Type: `integer`; Required: No; Default: `3600`\n- Unit: seconds\n- Function: Define preferred status cache duration.",
   },
   prefer_ipv6: {
+    probe_executor:
+      "- Type: `string`; required: no; default: unset (compatibility continuation probe mode)\n- Purpose: References an executor used only for the internal preferred-QTYPE probe. Enter a plain executor tag without `$`.\n- Runtime impact: May reference `forward`, `sequence`, or another executor that can independently produce a DNS response. Probe marks, extensions, and execution-path state stay isolated from the outer context.\n- Cache limitation: Disable `cache` when the probe result depends on the client, marks, randomness, rate limits, or other request-scoped state.",
     cache:
       "- Type: `boolean`; required: no; default value: `true`\n- Function: Control whether to cache the preferred type existence status.",
     cache_ttl:

--- a/webui/lib/i18n/locales/en-US/plugin-defined.ts
+++ b/webui/lib/i18n/locales/en-US/plugin-defined.ts
@@ -988,6 +988,12 @@ export const enUSPluginDefined = {
       description:
         "Dual-stack optimizer that favors A records and suppresses alternative AAAA requests",
       fields: {
+        probe_executor: {
+          label: "Probe executor",
+          description:
+            "Specifies the executor used only for the internal preferred-QTYPE probe.",
+          placeholder: "probe_v4",
+        },
         cache: {
           label: "Cache preference status",
           description:
@@ -1004,6 +1010,12 @@ export const enUSPluginDefined = {
       description:
         "Dual stack optimizer, favoring AAAA records and suppressing alternative A requests",
       fields: {
+        probe_executor: {
+          label: "Probe executor",
+          description:
+            "Specifies the executor used only for the internal preferred-QTYPE probe.",
+          placeholder: "probe_v6",
+        },
         cache: {
           label: "Cache preference status",
           description:

--- a/webui/lib/i18n/locales/zh-CN/docs.ts
+++ b/webui/lib/i18n/locales/zh-CN/docs.ts
@@ -215,12 +215,16 @@ export const zhCNDocs = {
       "- 类型：`integer`；必填：否；默认值：`60`\n- 单位：秒\n- 作用：定义失败探测评分的保留时间。\n- 配置要求：启用缓存时必须大于 0。\n- 运行影响：失败缓存可避免不可达地址在短时间内被反复探测，同时允许较快恢复。",
   },
   prefer_ipv4: {
+    probe_executor:
+      "- 类型：`string`；必填：否；默认值：未配置（兼容 continuation 探针模式）\n- 作用：引用一个仅用于 preferred QTYPE 内部探针的 executor；填写不带 `$` 的普通 executor tag。\n- 运行影响：可引用 `forward`、`sequence` 或其他能够独立生成 DNS response 的 executor。探针上下文与外层隔离，探针路径的 marks、extensions 和执行路径不会提交外层。\n- 缓存限制：若探针结果依赖客户端、marks、随机、限流或其他请求级状态，应关闭 `cache`。",
     cache:
       "- 类型：`boolean`；必填：否；默认值：`true`\n- 作用：控制是否缓存 preferred 类型存在状态。",
     cache_ttl:
       "- 类型：`integer`；必填：否；默认值：`3600`\n- 单位：秒\n- 作用：定义 preferred 状态缓存时长。",
   },
   prefer_ipv6: {
+    probe_executor:
+      "- 类型：`string`；必填：否；默认值：未配置（兼容 continuation 探针模式）\n- 作用：引用一个仅用于 preferred QTYPE 内部探针的 executor；填写不带 `$` 的普通 executor tag。\n- 运行影响：可引用 `forward`、`sequence` 或其他能够独立生成 DNS response 的 executor。探针上下文与外层隔离，探针路径的 marks、extensions 和执行路径不会提交外层。\n- 缓存限制：若探针结果依赖客户端、marks、随机、限流或其他请求级状态，应关闭 `cache`。",
     cache:
       "- 类型：`boolean`；必填：否；默认值：`true`\n- 作用：控制是否缓存 preferred 类型存在状态。",
     cache_ttl:

--- a/webui/lib/i18n/locales/zh-CN/plugin-defined.ts
+++ b/webui/lib/i18n/locales/zh-CN/plugin-defined.ts
@@ -896,6 +896,11 @@ export const zhCNPluginDefined = {
       name: "Prefer IPv4",
       description: "双栈优选器，偏好 A 记录并抑制可替代的 AAAA 请求",
       fields: {
+        probe_executor: {
+          label: "探针执行器",
+          description: "指定仅用于 preferred QTYPE 内部探针的执行器。",
+          placeholder: "probe_v4",
+        },
         cache: {
           label: "缓存偏好状态",
           description: "控制是否缓存 preferred 类型存在状态。",
@@ -910,6 +915,11 @@ export const zhCNPluginDefined = {
       name: "Prefer IPv6",
       description: "双栈优选器，偏好 AAAA 记录并抑制可替代的 A 请求",
       fields: {
+        probe_executor: {
+          label: "探针执行器",
+          description: "指定仅用于 preferred QTYPE 内部探针的执行器。",
+          placeholder: "probe_v6",
+        },
         cache: {
           label: "缓存偏好状态",
           description: "控制是否缓存 preferred 类型存在状态。",

--- a/webui/lib/plugin-definitions/docs.ts
+++ b/webui/lib/plugin-definitions/docs.ts
@@ -199,12 +199,16 @@ export const pluginFieldDocs = {
       "- 类型：`integer`；必填：否；默认值：`60`\n- 单位：秒\n- 作用：定义失败探测评分的保留时间。\n- 配置要求：启用缓存时必须大于 0。\n- 运行影响：失败缓存可避免不可达地址在短时间内被反复探测，同时允许较快恢复。",
   },
   prefer_ipv4: {
+    probe_executor:
+      "- 类型：`string`；必填：否；默认值：未配置（兼容 continuation 探针模式）\n- 作用：引用一个仅用于 preferred QTYPE 内部探针的 executor；填写不带 `$` 的普通 executor tag。\n- 运行影响：可引用 `forward`、`sequence` 或其他能够独立生成 DNS response 的 executor。探针上下文与外层隔离，探针路径的 marks、extensions 和执行路径不会提交外层。\n- 缓存限制：若探针结果依赖客户端、marks、随机、限流或其他请求级状态，应关闭 `cache`。",
     cache:
       "- 类型：`boolean`；必填：否；默认值：`true`\n- 作用：控制是否缓存 preferred 类型存在状态。",
     cache_ttl:
       "- 类型：`integer`；必填：否；默认值：`3600`\n- 单位：秒\n- 作用：定义 preferred 状态缓存时长。",
   },
   prefer_ipv6: {
+    probe_executor:
+      "- 类型：`string`；必填：否；默认值：未配置（兼容 continuation 探针模式）\n- 作用：引用一个仅用于 preferred QTYPE 内部探针的 executor；填写不带 `$` 的普通 executor tag。\n- 运行影响：可引用 `forward`、`sequence` 或其他能够独立生成 DNS response 的 executor。探针上下文与外层隔离，探针路径的 marks、extensions 和执行路径不会提交外层。\n- 缓存限制：若探针结果依赖客户端、marks、随机、限流或其他请求级状态，应关闭 `cache`。",
     cache:
       "- 类型：`boolean`；必填：否；默认值：`true`\n- 作用：控制是否缓存 preferred 类型存在状态。",
     cache_ttl:

--- a/webui/lib/plugin-definitions/executor.ts
+++ b/webui/lib/plugin-definitions/executor.ts
@@ -937,6 +937,15 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
     icon: "Shuffle",
     configSchema: [
       {
+        key: "probe_executor",
+        description: "指定仅用于 preferred QTYPE 内部探针的执行器。",
+        label: "探针执行器",
+        type: "reference",
+        referenceTypes: ["executor"],
+        referencePrefix: "",
+        placeholder: "probe_v4",
+      },
+      {
         key: "cache",
         description: "控制是否缓存 preferred 类型存在状态。",
         label: "缓存偏好状态",
@@ -961,6 +970,15 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
     description: "双栈优选器，偏好 AAAA 记录并抑制可替代的 A 请求",
     icon: "Shuffle",
     configSchema: [
+      {
+        key: "probe_executor",
+        description: "指定仅用于 preferred QTYPE 内部探针的执行器。",
+        label: "探针执行器",
+        type: "reference",
+        referenceTypes: ["executor"],
+        referencePrefix: "",
+        placeholder: "probe_v6",
+      },
       {
         key: "cache",
         description: "控制是否缓存 preferred 类型存在状态。",


### PR DESCRIPTION
- Allow prefer_ipv4 and prefer_ipv6 to run preferred-family probes through a configured executor while preserving continuation compatibility.
- Isolate probe context state, classify probe failures safely, cache only definitive results, and cancel abandoned tasks.
- Add dependency validation, unit and integration coverage, WebUI configuration schema, and bilingual documentation.