### PR TITLE
feat(sequence): add multi-value mark replacement

### DIFF
--- a/docs/docs/configuration/sequence.md
+++ b/docs/docs/configuration/sequence.md
@@ -191,13 +191,35 @@ title: 执行链与控制流
 
 ### `mark ...`
 
-- 向 `DnsContext.marks` 写入一个或多个无符号整数 mark。
+- 向 `DnsContext.marks` 追加一个或多个无符号整数 mark，保留集合中已有的值。
 - 支持写法：
   - `mark 1`
   - `mark 1 2 3`
   - `mark 1,2,3`
 - 写入后会继续执行当前 `sequence` 的下一条规则。
 - 它本身不会生成响应，也不会终止当前 `sequence`。
+
+### `set_mark ...`
+
+- 用一个或多个无符号整数完整替换 `DnsContext.marks`，不会保留集合中原有的值。
+- 参数语法与 `mark` 一致：
+  - `set_mark 1`
+  - `set_mark 1 2 3`
+  - `set_mark 1,2,3`
+- 重复值会自动去重；mark 是集合，配置顺序没有运行时语义。
+- 至少需要一个值。缺少参数、负数、非数字或超出 `u32` 范围的值会导致 sequence 初始化失败。
+- 替换后会继续执行当前 `sequence` 的下一条规则，不生成响应，也不终止当前 `sequence`。
+- `set_mark` 替换整个集合，不区分“分类 mark”和“附加 mark”。如果需要保留某个值，必须把它明确写进新集合。
+
+例如：
+
+```yaml
+- exec: "mark 1,4"
+- exec: "set_mark 2,3"
+- exec: "mark 5"
+```
+
+最终 marks 为 `2,3,5`：`set_mark` 移除了已有的 `1,4`，后续 `mark` 再追加 `5`。
 
 ### `jump seq_tag`
 
@@ -233,7 +255,7 @@ title: 执行链与控制流
 - tag: child_seq
   type: sequence
   args:
-    - exec: "mark 2"
+    - exec: "set_mark 2,20"
     - exec: "return"
 
 - tag: parent_jump
@@ -251,5 +273,5 @@ title: 执行链与控制流
     - exec: "mark 3"
 ```
 
-- `parent_jump` 最终会留下 `1,2,3`，因为 `jump` 调用结束后会继续执行下一条。
-- `parent_goto` 最终只会留下 `1,2`，因为控制权不会回到 `goto` 之后。
+- `parent_jump` 最终会留下 `2,3,20`：子 sequence 与调用方共享同一个 `DnsContext`，因此 `set_mark` 会替换调用方先前写入的 `1`，随后父 sequence 继续追加 `3`。
+- `parent_goto` 最终只会留下 `2,20`，因为 `set_mark` 同样替换了 `1`，且控制权不会回到 `goto` 之后。

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/configuration/sequence.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/configuration/sequence.md
@@ -191,13 +191,35 @@ Besides calling plugins, `sequence.args[].exec` can also use built-in control fl
 
 ### `mark ...`
 
-- Inserts one or more unsigned integer marks into `DnsContext.marks`.
+- Appends one or more unsigned integer marks to `DnsContext.marks` while preserving existing values.
 - Supported forms:
   - `mark 1`
   - `mark 1 2 3`
   - `mark 1,2,3`
 - Continues to the next rule in the current `sequence`.
 - Does not build a response and does not terminate the current `sequence`.
+
+### `set_mark ...`
+
+- Replaces the complete `DnsContext.marks` collection with one or more unsigned integer marks; existing values are not preserved.
+- It accepts the same argument forms as `mark`:
+  - `set_mark 1`
+  - `set_mark 1 2 3`
+  - `set_mark 1,2,3`
+- Duplicate values are deduplicated. Marks form a set, so configuration order has no runtime meaning.
+- At least one value is required. Missing arguments, negative values, non-numeric values, and values outside the `u32` range cause sequence initialization to fail.
+- Continues to the next rule without building a response or terminating the current `sequence`.
+- `set_mark` replaces the entire collection; it does not distinguish classification marks from supplemental marks. Values that must be retained need to be included explicitly.
+
+For example:
+
+```yaml
+- exec: "mark 1,4"
+- exec: "set_mark 2,3"
+- exec: "mark 5"
+```
+
+The final marks are `2,3,5`: `set_mark` removes the existing `1,4`, then the following `mark` appends `5`.
 
 ### `jump seq_tag`
 
@@ -233,7 +255,7 @@ Example showing the difference between `jump` and `goto`:
 - tag: child_seq
   type: sequence
   args:
-    - exec: "mark 2"
+    - exec: "set_mark 2,20"
     - exec: "return"
 
 - tag: parent_jump
@@ -251,5 +273,5 @@ Example showing the difference between `jump` and `goto`:
     - exec: "mark 3"
 ```
 
-- `parent_jump` ends with marks `1,2,3` because execution resumes after `jump`.
-- `parent_goto` ends with marks `1,2` because execution never returns after `goto`.
+- `parent_jump` ends with marks `2,3,20`: the child and caller share the same `DnsContext`, so `set_mark` replaces the caller's earlier `1`, and the parent appends `3` after the child returns.
+- `parent_goto` ends with marks `2,20` because `set_mark` also replaces `1` and execution never returns after `goto`.

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -203,6 +203,28 @@ plugins:
     }
 
     #[test]
+    fn print_dependency_graph_renders_set_mark_as_builtin_without_dependencies() {
+        let summary = config::validate_text(
+            r#"
+plugins:
+  - tag: seq
+    type: sequence
+    args:
+      - exec: set_mark 2,3
+  - tag: udp_server
+    type: udp_server
+    args:
+      entry: seq
+"#,
+        )
+        .expect("config should validate");
+
+        let graph = render_dependency_graph(&summary);
+        assert!(graph.contains("THEN set_mark 2,3 [args[0].exec]"));
+        assert!(!graph.contains("quick_setup(set_mark)"));
+    }
+
+    #[test]
     fn print_dependency_graph_shows_quick_setup_provider_deps_under_rule() {
         let summary = config::validate_text(
             r#"

--- a/src/plugin/executor/sequence/chain.rs
+++ b/src/plugin/executor/sequence/chain.rs
@@ -11,7 +11,7 @@ use crate::core::context::DnsContext;
 use crate::core::context::ExecutionPathEvent;
 use crate::infra::error::{DnsError, Result};
 use crate::plugin::executor::sequence::{
-    PluginRef, Rule, parse_control_flow_sequence_tag, parse_matcher_expr,
+    BuiltinKind, PluginRef, Rule, parse_control_flow_sequence_tag, parse_matcher_expr,
 };
 use crate::plugin::executor::{ExecStep, Executor};
 use crate::plugin::matcher::{Matcher, MatcherRef};
@@ -45,8 +45,27 @@ enum BuiltinOp {
     Jump(Arc<dyn Executor>),
     /// Execute another sequence executor and stop current program immediately.
     Goto(Arc<dyn Executor>),
-    /// Insert marks into context and continue execution.
-    Mark(AHashSet<u32>),
+    /// Mutate the request-local mark collection and continue execution.
+    Mark {
+        mode: MarkMutationMode,
+        values: AHashSet<u32>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum MarkMutationMode {
+    Append,
+    Replace,
+}
+
+impl MarkMutationMode {
+    #[cfg(feature = "_sequence-step-recording")]
+    fn builtin_name(self) -> &'static str {
+        match self {
+            Self::Append => "mark",
+            Self::Replace => "set_mark",
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -345,14 +364,18 @@ impl ChainProgram {
                     Err(err)
                 }
             },
-            BuiltinOp::Mark(marks) => {
-                context.marks_mut().extend(marks.iter().cloned());
+            BuiltinOp::Mark { mode, values } => {
+                let context_marks = context.marks_mut();
+                if *mode == MarkMutationMode::Replace {
+                    context_marks.clear();
+                }
+                context_marks.extend(values.iter().copied());
                 record_sequence_event!(
                     self,
                     context,
                     _instruction.node_index,
                     "builtin",
-                    Some("mark"),
+                    Some(mode.builtin_name()),
                     "next",
                 );
                 Ok(InstructionFlow::Continue)
@@ -541,20 +564,27 @@ impl<'a> ChainBuilder<'a> {
         let op = split.next().unwrap_or_default();
         let arg = split.next().map(str::trim).filter(|s| !s.is_empty());
 
-        match op {
-            "accept" => Ok(Some(BuiltinOp::Accept)),
-            "return" => Ok(Some(BuiltinOp::Return)),
-            "reject" => parse_reject_builtin(arg).map(Some),
-            "mark" => Ok(Some(BuiltinOp::Mark(parse_mark_values(arg)?))),
-            "jump" => Ok(Some(BuiltinOp::Jump(
+        match BuiltinKind::from_keyword(op) {
+            Some(BuiltinKind::Accept) => Ok(Some(BuiltinOp::Accept)),
+            Some(BuiltinKind::Return) => Ok(Some(BuiltinOp::Return)),
+            Some(BuiltinKind::Reject) => parse_reject_builtin(arg).map(Some),
+            Some(BuiltinKind::Mark) => Ok(Some(BuiltinOp::Mark {
+                mode: MarkMutationMode::Append,
+                values: parse_mark_values("mark", arg)?,
+            })),
+            Some(BuiltinKind::SetMark) => Ok(Some(BuiltinOp::Mark {
+                mode: MarkMutationMode::Replace,
+                values: parse_mark_values("set_mark", arg)?,
+            })),
+            Some(BuiltinKind::Jump) => Ok(Some(BuiltinOp::Jump(
                 self.resolve_jump_or_goto_executor("jump", arg, node_index)
                     .await?,
             ))),
-            "goto" => Ok(Some(BuiltinOp::Goto(
+            Some(BuiltinKind::Goto) => Ok(Some(BuiltinOp::Goto(
                 self.resolve_jump_or_goto_executor("goto", arg, node_index)
                     .await?,
             ))),
-            _ => Ok(None),
+            None => Ok(None),
         }
     }
 
@@ -675,15 +705,18 @@ fn parse_reject_builtin(arg: Option<&str>) -> Result<BuiltinOp> {
     Ok(BuiltinOp::Reject { rcode })
 }
 
-/// Parse optional `mark` arguments into normalized mark strings.
+/// Parse mark mutation arguments into a normalized mark set.
 ///
 /// Supported syntax:
 /// - `mark 1`
 /// - `mark 1,2,3`
 /// - `mark 1 2 3`
-fn parse_mark_values(arg: Option<&str>) -> Result<AHashSet<u32>> {
+fn parse_mark_values(op: &str, arg: Option<&str>) -> Result<AHashSet<u32>> {
     let Some(raw) = arg else {
-        return Err(DnsError::plugin("mark requires at least one value"));
+        return Err(DnsError::plugin(format!(
+            "{} requires at least one value",
+            op
+        )));
     };
 
     let mut marks = AHashSet::new();
@@ -694,12 +727,15 @@ fn parse_mark_values(arg: Option<&str>) -> Result<AHashSet<u32>> {
     {
         let mark = token
             .parse::<u32>()
-            .map_err(|e| DnsError::plugin(format!("invalid mark value '{}': {}", token, e)))?;
+            .map_err(|e| DnsError::plugin(format!("invalid {} value '{}': {}", op, token, e)))?;
         marks.insert(mark);
     }
 
     if marks.is_empty() {
-        return Err(DnsError::plugin("mark requires at least one value"));
+        return Err(DnsError::plugin(format!(
+            "{} requires at least one value",
+            op
+        )));
     }
 
     Ok(marks)
@@ -855,6 +891,87 @@ mod tests {
         Instruction::new(0, Vec::new(), InstructionOp::Builtin(op))
     }
 
+    fn mark_values(values: impl IntoIterator<Item = u32>) -> AHashSet<u32> {
+        values.into_iter().collect()
+    }
+
+    #[tokio::test]
+    async fn test_mark_mutations_append_and_replace_context_marks() {
+        let program = Arc::new(ChainProgram::new(
+            "test_sequence".to_string(),
+            vec![
+                builtin_instruction(BuiltinOp::Mark {
+                    mode: MarkMutationMode::Replace,
+                    values: mark_values([2, 3]),
+                }),
+                builtin_instruction(BuiltinOp::Mark {
+                    mode: MarkMutationMode::Append,
+                    values: mark_values([3, 5]),
+                }),
+            ],
+        ));
+        let mut context = make_context();
+        context.marks_mut().extend([1, 4]);
+
+        let step = program.run(&mut context).await.unwrap();
+
+        assert_eq!(step, ExecStep::Next);
+        assert_eq!(context.marks(), &mark_values([2, 3, 5]));
+    }
+
+    #[tokio::test]
+    async fn test_set_mark_does_not_run_when_instruction_matchers_fail() {
+        let program = Arc::new(ChainProgram::new(
+            "test_sequence".to_string(),
+            vec![Instruction::new(
+                0,
+                vec![MatcherRef::new(Arc::new(AlwaysMatcher), true)],
+                InstructionOp::Builtin(BuiltinOp::Mark {
+                    mode: MarkMutationMode::Replace,
+                    values: mark_values([2, 3]),
+                }),
+            )],
+        ));
+        let mut context = make_context();
+        context.marks_mut().extend([1, 4]);
+
+        let step = program.run(&mut context).await.unwrap();
+
+        assert_eq!(step, ExecStep::Next);
+        assert_eq!(context.marks(), &mark_values([1, 4]));
+    }
+
+    #[test]
+    fn test_parse_mark_values_supports_single_multiple_and_u32_bounds() {
+        assert_eq!(
+            parse_mark_values("set_mark", Some("7")).unwrap(),
+            mark_values([7])
+        );
+        assert_eq!(
+            parse_mark_values("set_mark", Some("0 7,7,4294967295")).unwrap(),
+            mark_values([0, 7, u32::MAX])
+        );
+    }
+
+    #[test]
+    fn test_parse_mark_values_rejects_missing_invalid_and_overflow_values() {
+        for arg in [None, Some(""), Some(",,")] {
+            let err = parse_mark_values("set_mark", arg).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("set_mark requires at least one value")
+            );
+        }
+
+        for value in ["-1", "abc", "4294967296"] {
+            let err = parse_mark_values("set_mark", Some(value)).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains(&format!("invalid set_mark value '{}'", value))
+            );
+        }
+    }
+
     #[cfg(feature = "_sequence-step-recording")]
     #[tokio::test]
     async fn test_sequence_records_execution_path_with_step_recording_feature() {
@@ -873,6 +990,29 @@ mod tests {
         assert_eq!(events[0].kind, "builtin");
         assert_eq!(events[0].tag.as_deref(), Some("accept"));
         assert_eq!(events[0].outcome, "stop");
+    }
+
+    #[cfg(feature = "_sequence-step-recording")]
+    #[tokio::test]
+    async fn test_set_mark_records_builtin_execution_path() {
+        let program = Arc::new(ChainProgram::new(
+            "test_sequence".to_string(),
+            vec![builtin_instruction(BuiltinOp::Mark {
+                mode: MarkMutationMode::Replace,
+                values: mark_values([2, 3]),
+            })],
+        ));
+        let mut context = make_context();
+        context.enable_execution_path();
+
+        let step = program.run(&mut context).await.unwrap();
+
+        assert_eq!(step, ExecStep::Next);
+        let events = context.execution_path_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "builtin");
+        assert_eq!(events[0].tag.as_deref(), Some("set_mark"));
+        assert_eq!(events[0].outcome, "next");
     }
 
     #[cfg(feature = "_sequence-step-recording")]

--- a/src/plugin/executor/sequence/mod.rs
+++ b/src/plugin/executor/sequence/mod.rs
@@ -26,6 +26,44 @@ use crate::plugin_factory;
 
 pub mod chain;
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(super) enum BuiltinKind {
+    Accept,
+    Return,
+    Reject,
+    Jump,
+    Goto,
+    Mark,
+    SetMark,
+}
+
+impl BuiltinKind {
+    pub(super) fn from_keyword(keyword: &str) -> Option<Self> {
+        match keyword {
+            "accept" => Some(Self::Accept),
+            "return" => Some(Self::Return),
+            "reject" => Some(Self::Reject),
+            "jump" => Some(Self::Jump),
+            "goto" => Some(Self::Goto),
+            "mark" => Some(Self::Mark),
+            "set_mark" => Some(Self::SetMark),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Accept => "accept",
+            Self::Return => "return",
+            Self::Reject => "reject",
+            Self::Jump => "jump",
+            Self::Goto => "goto",
+            Self::Mark => "mark",
+            Self::SetMark => "set_mark",
+        }
+    }
+}
+
 pub(super) fn parse_control_flow_sequence_tag(op: &str, raw: &str) -> DnsResult<String> {
     let tag = raw.trim();
     if tag.is_empty() {
@@ -139,13 +177,15 @@ impl Executor for Sequence {
 fn parse_control_flow_dependency(exec: &str) -> Option<String> {
     let mut split = exec.trim().splitn(2, char::is_whitespace);
     let op = split.next()?;
+    let kind = BuiltinKind::from_keyword(op)?;
+    if !matches!(kind, BuiltinKind::Jump | BuiltinKind::Goto) {
+        return None;
+    }
     let arg = split.next()?.trim();
     if arg.is_empty() {
         return None;
     }
-    if (op == "jump" || op == "goto")
-        && let Ok(tag) = parse_control_flow_sequence_tag(op, arg)
-    {
+    if let Ok(tag) = parse_control_flow_sequence_tag(op, arg) {
         return Some(tag);
     }
     None
@@ -270,24 +310,18 @@ fn analyze_builtin_exec_expression(field: &str, raw: &str) -> Option<SequenceFlo
     let trimmed = raw.trim();
     let mut split = trimmed.splitn(2, char::is_whitespace);
     let op = split.next()?;
+    let kind = BuiltinKind::from_keyword(op)?;
     let param = split
         .next()
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    let is_builtin = matches!(
-        op,
-        "accept" | "return" | "reject" | "jump" | "goto" | "mark"
-    );
-    if !is_builtin {
-        return None;
-    }
 
-    let target_tag = if matches!(op, "jump" | "goto") {
+    let target_tag = if matches!(kind, BuiltinKind::Jump | BuiltinKind::Goto) {
         param.and_then(|tag| parse_control_flow_sequence_tag(op, tag).ok())
     } else {
         None
     };
-    let plugin_type = if matches!(op, "jump" | "goto") {
+    let plugin_type = if matches!(kind, BuiltinKind::Jump | BuiltinKind::Goto) {
         Some("sequence".to_string())
     } else {
         None
@@ -301,7 +335,7 @@ fn analyze_builtin_exec_expression(field: &str, raw: &str) -> Option<SequenceFlo
         plugin_type,
         param: param.map(str::to_string),
         inverted: false,
-        builtin: Some(op.to_string()),
+        builtin: Some(kind.as_str().to_string()),
     })
 }
 
@@ -344,8 +378,14 @@ impl PluginFactory for SequenceFactory {
             }
             if let Some(exec) = rule.exec {
                 let field = format!("args[{}].exec", rule_idx);
-                if let Some(tag) = parse_control_flow_dependency(&exec) {
-                    result.push(DependencySpec::executor_type(field, tag, "sequence"));
+                let op = exec
+                    .trim()
+                    .split_once(char::is_whitespace)
+                    .map_or(exec.trim(), |(op, _)| op);
+                if BuiltinKind::from_keyword(op).is_some() {
+                    if let Some(tag) = parse_control_flow_dependency(&exec) {
+                        result.push(DependencySpec::executor_type(field, tag, "sequence"));
+                    }
                 } else {
                     match PluginRef::from_str(&exec) {
                         Ok(PluginRef::PluginTag(tag)) => {
@@ -537,5 +577,33 @@ exec: reject 2
                 .and_then(|expr| expr.builtin.as_deref()),
             Some("accept")
         );
+    }
+
+    #[test]
+    fn test_set_mark_is_reported_as_dependency_free_builtin() {
+        let config = PluginConfig {
+            tag: "seq".to_string(),
+            plugin_type: "sequence".to_string(),
+            args: Some(
+                serde_yaml_ng::from_str(
+                    r#"
+- exec: "set_mark 2,3"
+"#,
+                )
+                .expect("sequence args should parse"),
+            ),
+        };
+
+        let flow = analyze_sequence_flow(&config).expect("sequence flow should parse");
+        let exec = flow.rules[0]
+            .exec
+            .as_ref()
+            .expect("set_mark rule should have an action");
+        assert_eq!(exec.kind, SequenceFlowExpressionKind::Builtin);
+        assert_eq!(exec.builtin.as_deref(), Some("set_mark"));
+        assert_eq!(exec.param.as_deref(), Some("2,3"));
+        assert_eq!(exec.target_tag, None);
+
+        assert!(SequenceFactory {}.get_dependency_specs(&config).is_empty());
     }
 }

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -1253,6 +1253,76 @@ plugins:
 }
 
 #[tokio::test]
+async fn test_sequence_set_mark_replaces_multiple_marks_across_jump() -> Result<()> {
+    let yaml = r#"
+log:
+  level: info
+plugins:
+  - tag: child
+    type: sequence
+    args:
+      - exec: set_mark 2,3
+      - exec: return
+  - tag: parent
+    type: sequence
+    args:
+      - exec: mark 1 4
+      - exec: jump child
+      - exec: mark 5
+"#;
+
+    let config = parse_config(yaml)?;
+    let registry = plugin::init(config).await?;
+    let sequence = registry
+        .get_plugin("parent")
+        .expect("parent sequence should exist")
+        .to_executor();
+    let mut context = make_context(registry.clone(), "example.com.");
+
+    let step = sequence.execute(&mut context).await?;
+
+    assert!(matches!(step, ExecStep::Next));
+    assert_eq!(context.marks().len(), 3);
+    assert!(context.marks().contains(&2));
+    assert!(context.marks().contains(&3));
+    assert!(context.marks().contains(&5));
+    assert!(!context.marks().contains(&1));
+    assert!(!context.marks().contains(&4));
+
+    registry.destroy().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sequence_set_mark_rejects_invalid_values_during_init() -> Result<()> {
+    for exec in [
+        "set_mark",
+        "set_mark -1",
+        "set_mark abc",
+        "set_mark 4294967296",
+    ] {
+        let yaml = format!(
+            r#"
+log:
+  level: info
+plugins:
+  - tag: seq
+    type: sequence
+    args:
+      - exec: "{exec}"
+"#
+        );
+        let config = parse_config(&yaml)?;
+        let err = plugin::init(config)
+            .await
+            .expect_err("invalid set_mark value should fail sequence initialization");
+        assert!(err.to_string().contains("set_mark"));
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_sequence_quick_setup_matchers_accept_enum_text() -> Result<()> {
     let yaml = r#"
 log:

--- a/webui/components/plugins/sequence-composer.tsx
+++ b/webui/components/plugins/sequence-composer.tsx
@@ -65,7 +65,14 @@ import { useI18n } from "@/lib/i18n/provider";
 
 type ConditionMode = "reference" | "quick_setup" | "text";
 type ActionMode = "reference" | "quick_setup" | "control" | "text";
-type ControlKind = "accept" | "return" | "reject" | "mark" | "jump" | "goto";
+type ControlKind =
+  | "accept"
+  | "return"
+  | "reject"
+  | "mark"
+  | "set_mark"
+  | "jump"
+  | "goto";
 
 type SequenceFlowNode =
   | Node<RuleNodeData, "rule">
@@ -155,6 +162,7 @@ const controlLabels: Record<ControlKind, string> = {
   return: "return",
   reject: "reject",
   mark: "mark",
+  set_mark: "set_mark",
   jump: "jump",
   goto: "goto",
 };
@@ -164,6 +172,7 @@ const builtinControls: ControlKind[] = [
   "return",
   "reject",
   "mark",
+  "set_mark",
   "jump",
   "goto",
 ];

--- a/webui/lib/i18n/locales/en-US/plugin-defined.ts
+++ b/webui/lib/i18n/locales/en-US/plugin-defined.ts
@@ -313,9 +313,9 @@ export const enUSPluginDefined = {
         "args[].exec": {
           label: "perform action",
           description:
-            "Defines the action to perform when the rule matches. You can reference an executor or use built-in actions such as accept, return, reject, jump, goto, and mark; reject accepts case-insensitive RCODE names and numeric values.",
+            "Defines the action to perform when the rule matches. You can reference an executor or use built-in actions such as accept, return, reject, jump, goto, mark, and set_mark. mark appends values, while set_mark replaces the complete mark set; reject accepts case-insensitive RCODE names and numeric values.",
           placeholder:
-            "$forward_main / accept / reject SERVFAIL / reject NOERROR / reject 3 / jump seq_tag",
+            "$forward_main / accept / reject SERVFAIL / mark 1,2 / set_mark 2,3 / jump seq_tag",
         },
       },
     },

--- a/webui/lib/i18n/locales/zh-CN/plugin-defined.ts
+++ b/webui/lib/i18n/locales/zh-CN/plugin-defined.ts
@@ -278,9 +278,9 @@ export const zhCNPluginDefined = {
         "args[].exec": {
           label: "执行动作",
           description:
-            "定义规则命中后要执行的动作，可引用执行器或使用 accept、return、reject、jump、goto、mark 等内置动作；reject 支持大小写不敏感的 RCODE 名称和数字。",
+            "定义规则命中后要执行的动作，可引用执行器或使用 accept、return、reject、jump、goto、mark、set_mark 等内置动作；mark 追加标记，set_mark 完整替换标记集合；reject 支持大小写不敏感的 RCODE 名称和数字。",
           placeholder:
-            "$forward_main / accept / reject SERVFAIL / reject NOERROR / reject 3 / jump seq_tag",
+            "$forward_main / accept / reject SERVFAIL / mark 1,2 / set_mark 2,3 / jump seq_tag",
         },
       },
     },

--- a/webui/lib/oxidns-yaml-codemirror.ts
+++ b/webui/lib/oxidns-yaml-codemirror.ts
@@ -74,12 +74,22 @@ export interface OxiDnsYamlDiagnostic {
   end_column?: number;
 }
 
-const sequenceControls = ["accept", "return", "reject", "mark", "jump", "goto"];
+const sequenceControls = [
+  "accept",
+  "return",
+  "reject",
+  "mark",
+  "set_mark",
+  "jump",
+  "goto",
+];
 const sequenceControlExamples = [
   "reject SERVFAIL",
   "reject servfail",
   "reject NOERROR",
   "reject 3",
+  "mark 1,2",
+  "set_mark 2,3",
 ];
 const editorFontFamily =
   "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Consolas, Liberation Mono, monospace";

--- a/webui/lib/plugin-definitions/executor.ts
+++ b/webui/lib/plugin-definitions/executor.ts
@@ -54,11 +54,11 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
             {
               key: "exec",
               description:
-                "定义规则命中后要执行的动作，可引用执行器或使用 accept、return、reject、jump、goto、mark 等内置动作；reject 支持大小写不敏感的 RCODE 名称和数字。",
+                "定义规则命中后要执行的动作，可引用执行器或使用 accept、return、reject、jump、goto、mark、set_mark 等内置动作；mark 追加标记，set_mark 完整替换标记集合；reject 支持大小写不敏感的 RCODE 名称和数字。",
               label: "执行动作",
               type: "text",
               placeholder:
-                "$forward_main / accept / reject SERVFAIL / reject NOERROR / reject 3 / jump seq_tag",
+                "$forward_main / accept / reject SERVFAIL / mark 1,2 / set_mark 2,3 / jump seq_tag",
             },
           ],
         },


### PR DESCRIPTION
- Add `set_mark` with shared u32 list parsing and exact mark-set replacement while preserving `mark` append semantics.
- Keep dependency analysis, execution-path reporting, WebUI editing, YAML completion, and bilingual documentation aligned.
- Cover runtime behavior, cross-sequence control flow, invalid values, and dependency-graph rendering with tests.

Closed #311