### PR TITLE
perf(infra): reduce idle memory allocations

### DIFF
--- a/src/infra/network/buffer_pool.rs
+++ b/src/infra/network/buffer_pool.rs
@@ -13,6 +13,7 @@
 //!
 //! - it stores `Vec<u8>` only;
 //! - it always returns buffers with the same DNS-oriented capacity;
+//! - it grows lazily to the configured retention limit;
 //! - callers borrow buffers via an RAII wrapper; and
 //! - buffers that grew beyond the fixed capacity are replaced on return.
 
@@ -45,9 +46,6 @@ impl WireBufferPool {
     fn new(buffer_capacity: usize, pool_size: usize) -> Self {
         let pool_size = pool_size.max(1);
         let buffers = ArrayQueue::new(pool_size);
-        for _ in 0..pool_size {
-            let _ = buffers.push(Vec::with_capacity(buffer_capacity.max(1)));
-        }
 
         Self {
             buffer_capacity: buffer_capacity.max(1),
@@ -171,7 +169,7 @@ mod tests {
     #[test]
     fn test_acquire_reuses_buffer_from_matching_bucket() {
         let pool = WireBufferPool::new(8191, 1);
-        assert_eq!(pool.available(), 1);
+        assert_eq!(pool.available(), 0);
 
         let capacity = {
             let buffer = pool.acquire();
@@ -189,7 +187,7 @@ mod tests {
     #[test]
     fn test_release_replaces_grown_buffer_with_fixed_capacity() {
         let pool = WireBufferPool::new(8191, 1);
-        assert_eq!(pool.available(), 1);
+        assert_eq!(pool.available(), 0);
 
         {
             let mut buffer = pool.acquire();
@@ -213,5 +211,20 @@ mod tests {
 
         assert_eq!(small.capacity(), 8191);
         assert_eq!(large.capacity(), 8191);
+    }
+
+    #[test]
+    fn test_pool_retains_only_up_to_its_limit() {
+        let pool = WireBufferPool::new(8191, 2);
+        let first = pool.acquire();
+        let second = pool.acquire();
+        let third = pool.acquire();
+
+        assert_eq!(pool.available(), 0);
+        drop(first);
+        drop(second);
+        drop(third);
+
+        assert_eq!(pool.available(), 2);
     }
 }

--- a/src/infra/observability/logging.rs
+++ b/src/infra/observability/logging.rs
@@ -23,7 +23,10 @@ use crate::infra::clock::AppClock;
 use crate::infra::observability::log_buffer::{LogBuffer, LogLayer, install_global_log_buffer};
 
 /// Initialize the logging system with console and optional file output.
-pub fn start_logging(log: LogConfig) -> WorkerGuard {
+///
+/// The returned guard is present only when file output uses the background
+/// writer and must remain alive until shutdown so pending records are flushed.
+pub(crate) fn start_logging(log: LogConfig) -> Option<WorkerGuard> {
     let (file_writer, guard) = if let Some(ref file_path) = log.file {
         let file_appender = build_file_appender(file_path, &log.rotation)
             .unwrap_or_else(|err| panic!("failed to initialize log file appender: {err}"));
@@ -80,7 +83,7 @@ pub fn start_logging(log: LogConfig) -> WorkerGuard {
         info!(level = %log.level, "Logging system initialized");
     }
 
-    guard.unwrap_or_else(|| tracing_appender::non_blocking(std::io::sink()).1)
+    guard
 }
 
 fn build_file_appender(path: &str, rotation: &LogRotation) -> std::io::Result<RollingFileAppender> {


### PR DESCRIPTION
- Allocate wire buffers lazily while preserving the configured pool limit.
- Avoid creating a background sink logger when file logging is disabled.
- Add coverage for lazy reuse and pool retention bounds.