### PR TITLE
fix(service): make Windows SCM restarts reliable

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -121,7 +121,9 @@ pub(crate) fn exec_restart() -> Result<()> {
         if windows_running_as_service() {
             // Under Windows SCM: do not spawn a duplicate — SCM will restart the
             // service on our behalf. Exit with a non-zero code to trigger the
-            // OnFailure restart policy configured at install time.
+            // configured recovery action. Reapply it here so installations made
+            // by older OxiDNS versions are repaired before the process exits.
+            crate::infra::service::configure_windows_restart_recovery()?;
             std::process::exit(1);
         } else {
             // Foreground mode: spawn the replacement process then exit cleanly.

--- a/src/app.rs
+++ b/src/app.rs
@@ -50,6 +50,18 @@ pub struct StartConfig {
 
 /// Start OxiDNS in the foreground using the provided CLI options.
 pub fn run(start: StartConfig) -> Result<()> {
+    match run_until_shutdown(start)? {
+        ShutdownSignal::Restart => exec_restart(),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn run_windows_service(start: StartConfig) -> Result<ShutdownSignal> {
+    run_until_shutdown(start)
+}
+
+fn run_until_shutdown(start: StartConfig) -> Result<ShutdownSignal> {
     // Capture the exe path before any binary replacement can invalidate it.
     ORIGINAL_EXE.get_or_init(|| std::env::current_exe().unwrap_or_default());
     AppClock::start();
@@ -77,7 +89,7 @@ fn prepare_working_dir(working_dir: Option<&std::path::PathBuf>) -> Result<()> {
     Ok(())
 }
 
-fn init_runtime(options: StartConfig, config: Config) -> Result<()> {
+fn init_runtime(options: StartConfig, config: Config) -> Result<ShutdownSignal> {
     let worker_threads = config.runtime.effective_worker_threads();
     let mut tokio_runtime = runtime::Builder::new_multi_thread();
     tokio_runtime
@@ -87,10 +99,7 @@ fn init_runtime(options: StartConfig, config: Config) -> Result<()> {
     let tokio_runtime = tokio_runtime
         .build()
         .map_err(|err| DnsError::runtime(format!("Failed to initialize Tokio runtime: {err}")))?;
-    match tokio_runtime.block_on(run_async_main(options, config))? {
-        ShutdownSignal::Restart => exec_restart(),
-        _ => Ok(()),
-    }
+    tokio_runtime.block_on(run_async_main(options, config))
 }
 
 /// Replace the current process image with a fresh copy of OxiDNS using the
@@ -118,21 +127,13 @@ pub(crate) fn exec_restart() -> Result<()> {
 
     #[cfg(windows)]
     {
-        if windows_running_as_service() {
-            // Under Windows SCM: do not spawn a duplicate — SCM will restart the
-            // service on our behalf. Exit with a non-zero code to trigger the
-            // configured recovery action. Reapply it here so installations made
-            // by older OxiDNS versions are repaired before the process exits.
-            crate::infra::service::configure_windows_restart_recovery()?;
-            std::process::exit(1);
-        } else {
-            // Foreground mode: spawn the replacement process then exit cleanly.
-            std::process::Command::new(&exe)
-                .args(&args)
-                .spawn()
-                .map_err(|e| DnsError::runtime(format!("restart: spawn failed: {e}")))?;
-            std::process::exit(0);
-        }
+        // Windows services handle Restart in the SCM wrapper and never reach
+        // this foreground replacement path.
+        std::process::Command::new(&exe)
+            .args(&args)
+            .spawn()
+            .map_err(|e| DnsError::runtime(format!("restart: spawn failed: {e}")))?;
+        std::process::exit(0);
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -143,31 +144,6 @@ pub(crate) fn exec_restart() -> Result<()> {
             .map_err(|e| DnsError::runtime(format!("restart: spawn failed: {e}")))?;
         std::process::exit(0);
     }
-}
-
-/// Detect whether this process is running under the Windows Service Control
-/// Manager by checking if the parent process is `services.exe`.
-///
-/// Uses the already-available `sysinfo` crate — no extra dependencies needed.
-/// Falls back to `false` (assume foreground) on any lookup error.
-#[cfg(windows)]
-fn windows_running_as_service() -> bool {
-    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
-
-    let refresh = ProcessRefreshKind::nothing();
-    let mut sys = System::new_with_specifics(RefreshKind::nothing().with_processes(refresh));
-    sys.refresh_processes(ProcessesToUpdate::All, false);
-
-    let current_pid = Pid::from_u32(std::process::id());
-    sys.process(current_pid)
-        .and_then(|p| p.parent())
-        .and_then(|parent_pid| sys.process(parent_pid))
-        .is_some_and(|parent| {
-            parent
-                .name()
-                .to_string_lossy()
-                .eq_ignore_ascii_case("services.exe")
-        })
 }
 
 fn load_config(options: &StartConfig) -> Result<Config> {
@@ -181,7 +157,7 @@ fn load_config(options: &StartConfig) -> Result<Config> {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(super) enum ShutdownSignal {
+pub(crate) enum ShutdownSignal {
     ApiRequest,
     Restart,
     #[cfg(unix)]

--- a/src/infra/service.rs
+++ b/src/infra/service.rs
@@ -99,7 +99,7 @@ fn run_windows_service() -> Result<()> {
 
     let app_tx = shutdown_tx;
     let app_thread = std::thread::spawn(move || {
-        let result = crate::app::run(start_opts);
+        let result = crate::app::run_windows_service(start_opts);
         let _ = app_tx.send(());
         result
     });
@@ -115,7 +115,7 @@ fn run_windows_service() -> Result<()> {
 
     let _ = report(ServiceState::StopPending, ServiceControlAccept::empty(), 5);
 
-    let app_result = if app_thread.is_finished() {
+    let shutdown_signal = if app_thread.is_finished() {
         app_thread
             .join()
             .unwrap_or_else(|_| Err(DnsError::runtime("app thread panicked")))
@@ -123,10 +123,16 @@ fn run_windows_service() -> Result<()> {
         // App is still running after receiving stop — exit so SCM marks us stopped.
         let _ = report(ServiceState::Stopped, ServiceControlAccept::empty(), 0);
         std::process::exit(0);
-    };
+    }?;
+
+    if matches!(shutdown_signal, crate::app::ShutdownSignal::Restart) {
+        // Do not report a clean STOPPED state: terminate with a failure code so
+        // the SCM recovery action starts a fresh service process.
+        std::process::exit(1);
+    }
 
     let _ = report(ServiceState::Stopped, ServiceControlAccept::empty(), 0);
-    app_result
+    Ok(())
 }
 
 #[cfg(windows)]
@@ -272,16 +278,18 @@ pub fn install(options: ServiceInstallConfig) -> Result<()> {
 ///
 /// The `service-manager` Windows backend installs services through `sc create`,
 /// which cannot apply its `RestartPolicy`. Configure the equivalent recovery
-/// action through the native Windows service API instead. This is called both
-/// after installation and immediately before an in-service restart so that
-/// services installed by older OxiDNS versions are repaired in place.
+/// action through the native Windows service API after installation, while the
+/// installer is still running outside the SCM service dispatcher.
 #[cfg(windows)]
 pub(crate) fn configure_windows_restart_recovery() -> Result<()> {
     let manager =
         WindowsServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
             .map_err(|err| DnsError::runtime(format!("Failed to open Windows SCM: {err}")))?;
     let service = manager
-        .open_service(SERVICE_LABEL, ServiceAccess::CHANGE_CONFIG)
+        .open_service(
+            SERVICE_LABEL,
+            ServiceAccess::CHANGE_CONFIG | ServiceAccess::START,
+        )
         .map_err(|err| {
             DnsError::runtime(format!(
                 "Failed to open Windows service '{SERVICE_LABEL}' for recovery configuration: {err}"

--- a/src/infra/service.rs
+++ b/src/infra/service.rs
@@ -19,11 +19,13 @@ use service_manager::{
 use windows_service::{
     define_windows_service,
     service::{
-        ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState,
+        ServiceAccess, ServiceAction, ServiceActionType, ServiceControl, ServiceControlAccept,
+        ServiceExitCode, ServiceFailureActions, ServiceFailureResetPeriod, ServiceState,
         ServiceStatus as WinServiceStatus, ServiceType,
     },
     service_control_handler::{self, ServiceControlHandlerResult},
     service_dispatcher,
+    service_manager::{ServiceManager as WindowsServiceManager, ServiceManagerAccess},
 };
 
 use crate::infra::error::{DnsError, Result};
@@ -261,7 +263,61 @@ pub fn install(options: ServiceInstallConfig) -> Result<()> {
     manager
         .install(ctx)
         .map_err(|err| DnsError::runtime(format!("Failed to install service: {err}")))?;
+    #[cfg(windows)]
+    configure_windows_restart_recovery()?;
     Ok(())
+}
+
+/// Configure the SCM recovery action used by application-requested restarts.
+///
+/// The `service-manager` Windows backend installs services through `sc create`,
+/// which cannot apply its `RestartPolicy`. Configure the equivalent recovery
+/// action through the native Windows service API instead. This is called both
+/// after installation and immediately before an in-service restart so that
+/// services installed by older OxiDNS versions are repaired in place.
+#[cfg(windows)]
+pub(crate) fn configure_windows_restart_recovery() -> Result<()> {
+    let manager =
+        WindowsServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
+            .map_err(|err| DnsError::runtime(format!("Failed to open Windows SCM: {err}")))?;
+    let service = manager
+        .open_service(SERVICE_LABEL, ServiceAccess::CHANGE_CONFIG)
+        .map_err(|err| {
+            DnsError::runtime(format!(
+                "Failed to open Windows service '{SERVICE_LABEL}' for recovery configuration: {err}"
+            ))
+        })?;
+
+    service
+        .update_failure_actions(windows_restart_failure_actions())
+        .map_err(|err| {
+            DnsError::runtime(format!(
+                "Failed to configure Windows service restart recovery: {err}"
+            ))
+        })?;
+    service
+        .set_failure_actions_on_non_crash_failures(true)
+        .map_err(|err| {
+            DnsError::runtime(format!(
+                "Failed to enable Windows service restart recovery: {err}"
+            ))
+        })?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn windows_restart_failure_actions() -> ServiceFailureActions {
+    use std::time::Duration;
+
+    ServiceFailureActions {
+        reset_period: ServiceFailureResetPeriod::Never,
+        reboot_msg: None,
+        command: None,
+        actions: Some(vec![ServiceAction {
+            action_type: ServiceActionType::Restart,
+            delay: Duration::from_secs(3),
+        }]),
+    }
 }
 
 pub fn start() -> Result<()> {
@@ -351,6 +407,22 @@ fn normalize_config_path(path: &Path, working_dir: &Path) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_recovery_restarts_after_three_seconds() {
+        use std::time::Duration;
+
+        let recovery = windows_restart_failure_actions();
+        assert_eq!(recovery.reset_period, ServiceFailureResetPeriod::Never);
+        assert_eq!(
+            recovery.actions,
+            Some(vec![ServiceAction {
+                action_type: ServiceActionType::Restart,
+                delay: Duration::from_secs(3),
+            }])
+        );
+    }
 
     #[test]
     fn normalize_working_dir_rejects_relative_paths() {


### PR DESCRIPTION
 修复Windows上重启服务时，服务停止起不来了
Windows 10&11均有此问题

 ### 背景

  Windows 服务通过管理 API 请求重启时，OxiDNS 会结束当前进程，但 Windows Service Control Manager（SCM）可能将其视为正常停止，导致服务无法自动恢复。

  此外，`service-manager` 的 Windows 后端通过 `sc create` 安装服务，并不会实际应用配置中的 `RestartPolicy`，因此需要显式配置 SCM failure actions。

  ### 修改内容

  - 将应用运行结果中的 `Restart` 信号交还给 Windows 服务包装层处理。
  - Windows 前台运行仍通过启动新进程完成重启。
  - Windows 服务运行时不再依赖父进程名称判断 SCM 上下文。
  - 服务收到应用级重启信号后以非零状态退出，由 SCM 启动新服务进程。
  - 安装 Windows 服务后，通过原生 Windows service API 配置：
    - 失败后等待 3 秒重新启动；
    - 对非崩溃失败启用 failure actions；
    - failure count 永不重置。
  - 打开服务句柄时同时申请 `SERVICE_CHANGE_CONFIG` 和 `SERVICE_START` 权限，满足 `SC_ACTION_RESTART` 的权限要求。
  - 添加 Windows 恢复策略单元测试。

  ### 影响范围

  - 仅影响 Windows 服务模式。
  - Windows 前台运行和 Unix 重启行为保持不变。
  - 不修改配置文件格式或默认 DNS 行为。
  - 不影响 DNS 请求热路径。

  ### 验证

  执行了以下检查：

  - `cargo +nightly fmt --check`
  - `git diff --check`
  - `cargo build --release`
  - `cargo test --lib windows_recovery_restarts_after_three_seconds`

  实机验证：

  1. 重新安装并启动 Windows 服务。
  2. 确认 SCM 配置：
     - `FAILURE_ACTIONS: RESTART`
     - Delay：3000 ms
     - `FAILURE_ACTIONS_ON_NONCRASH_FAILURES: TRUE`
  3. 调用 `POST /api/restart`，返回 `202 Accepted`。
  4. 旧服务进程退出。
  5. SCM 在约 3 秒后启动新进程。
  6. 新旧 PID 和 health `instance_id` 均不同，确认服务完成真实重启。

  ---

<details>

<summary>English description</summary>

  ### Background

  When OxiDNS receives a restart request through the management API while running as a Windows service, the current process exits, but the Windows
  Service Control Manager (SCM) may treat it as a normal stop and leave the service offline.

  In addition, the Windows backend of `service-manager` installs services through `sc create`, which does not apply the configured `RestartPolicy`. SCM
  failure actions therefore need to be configured explicitly.

  ### Changes

  - Return the application-level `Restart` signal to the Windows service wrapper.
  - Preserve process-spawning restart behavior for foreground Windows execution.
  - Remove parent-process-name detection for determining whether OxiDNS is running under SCM.
  - Exit the Windows service process with a non-zero status after an application-requested restart so SCM can start a fresh service process.
  - Configure native Windows SCM failure actions after service installation:
    - restart after a 3-second delay;
    - enable failure actions for non-crash failures;
    - never reset the failure count.
  - Request both `SERVICE_CHANGE_CONFIG` and `SERVICE_START` access, as required when configuring `SC_ACTION_RESTART`.
  - Add a unit test for the Windows recovery action configuration.

  ### Scope and impact

  - Windows service mode only.
  - Foreground Windows and Unix restart behavior remain unchanged.
  - No configuration schema or default DNS behavior changes.
  - No impact on the DNS request hot path.

  ### Validation

  The following checks were run:

  - `cargo +nightly fmt --check`
  - `git diff --check`
  - `cargo build --release`
  - `cargo test --lib windows_recovery_restarts_after_three_seconds`

  Manual Windows service verification:

  1. Reinstalled and started the Windows service.
  2. Confirmed the SCM configuration:
     - `FAILURE_ACTIONS: RESTART`
     - Delay: 3000 ms
     - `FAILURE_ACTIONS_ON_NONCRASH_FAILURES: TRUE`
  3. Sent `POST /api/restart` and received `202 Accepted`.
  4. Observed the old service process exit.
  5. Observed SCM start a new process after approximately 3 seconds.
  6. Confirmed that both the PID and health `instance_id` changed.

</details>